### PR TITLE
feat(generators): add fal.ai backend support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,16 @@ __pycache__/
 *.so
 .Python
 
+research
+
 # Configuration files with sensitive information
 pipeline_config.yaml
 
 # Docker and deployment files
 .env
 .env.local
+.env.dev
+.env.prod
 credentials/
 certs/
 backup/

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
     *   `task`, `size`, `prompt`: Core details for your video.
 
 2.  **Backend Selection**:
-    *   `default_backend`: Specify your preferred video generation backend (e.g., "wan2.1", "hunyuan", "runway", "veo3", "minimax"). The system will attempt to use this backend first.
+    *   `default_backend`: Specify your preferred video generation backend (e.g., "wan2.1", "hunyuan", "runway", "veo3", "minimax", "fal", "fal.ai"). The system will attempt to use this backend first.
 
 3.  **Local Backend Configuration (Wan2.1)**:
     *   `wan2_dir`, `flf2v_model_dir`, `i2v_model_dir`: Paths for the local Wan2.1 setup.
@@ -134,23 +134,28 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
     *   `runway_ml`: Settings for Runway ML, including `api_key`, `model_version`, etc.
     *   `google_veo`: Settings for Google Veo, including `project_id`, `credentials_path`, etc.
     *   `minimax`: Settings for Minimax API, including `api_key`, `model_version`, etc.
+    *   `fal`: Settings for fal.ai, including `api_key`, `model`, optional `base_url`, and optional `default_input`.
 
 5.  **Remote API Settings (Common to all remote backends)**:
     *   `max_retries`, `timeout`: General settings for remote API calls.
-    *   `fallback_backend`: (Optional) Specify a backend (e.g., "wan2.1", "runway", "minimax") to use if the `default_backend` (if it's a remote API) fails. If not set, or if the specified fallback also fails, the system may try other available registered backends.
+    *   `fallback_backend`: (Optional) Specify a backend (e.g., "wan2.1", "runway", "minimax", "fal") to use if the `default_backend` (if it's a remote API) fails. If not set, or if the specified fallback also fails, the system may try other available registered backends.
 
-6.  **Cost Optimization**:
+6.  **fal.ai Metrics Output**:
+    *   When `default_backend` is `fal`/`fal.ai`, response headers such as cost and timing are captured when available.
+    *   Metrics are saved next to generated video output as `<output>.metrics.json`.
+
+7.  **Cost Optimization**:
     *   `max_cost_per_video`, `prefer_local_when_available`.
     *   `api_priority_order`: (Currently a placeholder for future advanced fallback strategies) Defines a preferred order if multiple remote APIs are configured. The current fallback logic is simpler (tries `fallback_backend` then iterates others).
 
-7.  **Image Generation Configuration**:
+8.  **Image Generation Configuration**:
     *   `image_generation_model`, `image_size`, API keys for image services (`image_router_api_key`, `stability_api_key`, `openai_api_key`).
 
-8.  **Generation Parameters (Applies to all video backends)**:
+9.  **Generation Parameters (Applies to all video backends)**:
     *   `segment_duration_seconds`: Desired duration for each video segment in seconds (e.g., 5.0). Crucial for chaining mode.
     *   `frame_num`, `sample_steps`, `guide_scale`, `base_seed`, etc.
 
-9.  **Output and Logging Configuration**.
+10.  **Output and Logging Configuration**.
 
 #### GPU Parallelization (for Local Wan2.1 Backend)
 When using the local Wan2.1 backend, the pipeline supports distributed processing and parallel segment generation:

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -127,13 +127,14 @@ The entire system behavior is controlled through a comprehensive YAML configurat
 ### Key Configuration Parameters
 
 **Backend Selection:**
-- `default_backend`: Choose from `"wan2.1"`, `"hunyuan"`, `"runway"`, `"veo3"`, `"minimax"` - [`generators/factory.py`](../generators/factory.py)
+- `default_backend`: Choose from `"wan2.1"`, `"hunyuan"`, `"runway"`, `"veo3"`, `"minimax"`, `"fal"`, `"fal.ai"` - [`generators/factory.py`](../generators/factory.py)
 
 **Backend-Specific Settings:**
 - `wan2_dir`: Local Wan2.1 setup - [`generators/local/wan21_generator.py`](../generators/local/wan21_generator.py)
 - `runway_ml`: Runway API configuration - [`generators/remote/runway_generator.py`](../generators/remote/runway_generator.py)
 - `google_veo`: Veo3 API configuration - [`generators/remote/veo3_generator.py`](../generators/remote/veo3_generator.py)
 - `minimax`: Minimax API configuration - [`generators/remote/minimax_generator.py`](../generators/remote/minimax_generator.py)
+- `fal`: fal.ai API configuration - [`generators/remote/fal_generator.py`](../generators/remote/fal_generator.py)
 - `hunyuan_video`: Local HunyuanVideo configuration - [`generators/local/hunyuan_video_generator.py`](../generators/local/hunyuan_video_generator.py)
 
 **Generation Control:**

--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -83,6 +83,7 @@ The pipeline is configured through `pipeline_config.yaml`, which you must create
    - `veo3` - Google Veo 3 API (requires GCP setup)
    - `runway` - Runway ML API (requires API key)
    - `minimax` - Minimax API (requires API key)
+   - `fal` / `fal.ai` - fal.ai model endpoint (requires API key + model)
    - `auto` - Automatic backend selection with fallback
 
 3. **Configure API keys** (for remote backends):
@@ -90,6 +91,7 @@ The pipeline is configured through `pipeline_config.yaml`, which you must create
    - **Runway ML**: Set `runway_ml.api_key`
    - **Google Veo**: Set `google_veo.project_id` and `credentials_path`
    - **Minimax**: Set `minimax.api_key` or environment variable `MINIMAX_API_KEY`
+   - **fal.ai**: Set `fal.api_key` or environment variable `FAL_API_KEY`, and set `fal.model`
    - **Stability AI**: Set `stability_api_key`
 
 *Source: [`pipeline_config.yaml.sample`](../pipeline_config.yaml.sample)*

--- a/docs/04-video-generation-backends.md
+++ b/docs/04-video-generation-backends.md
@@ -2,7 +2,7 @@
 
 *Source: [DeepWiki Analysis](https://deepwiki.com/trilogy-group/ttv-pipeline/4-video-generation-backends)*
 
-The video generation backends system provides a unified abstraction layer for multiple video generation technologies within the TTV Pipeline. This system enables seamless switching between local GPU-based models (such as Wan2.1) and remote cloud APIs (such as Runway ML, Google Veo 3, and Minimax) through a common interface and factory pattern.
+The video generation backends system provides a unified abstraction layer for multiple video generation technologies within the TTV Pipeline. This system enables seamless switching between local GPU-based models (such as Wan2.1) and remote cloud APIs (such as Runway ML, Google Veo 3, Minimax, and fal.ai) through a common interface and factory pattern.
 
 **Key Source Files:**
 - [`generators/__init__.py`](../generators/__init__.py) - Package exports and factory function
@@ -11,7 +11,7 @@ The video generation backends system provides a unified abstraction layer for mu
 
 ## Purpose and Scope
 
-The video generation backends system provides a unified abstraction layer for multiple video generation technologies within the TTV Pipeline. This system enables seamless switching between local GPU-based models (such as Wan2.1) and remote cloud APIs (such as Runway ML, Google Veo 3, and Minimax) through a common interface and factory pattern.
+The video generation backends system provides a unified abstraction layer for multiple video generation technologies within the TTV Pipeline. This system enables seamless switching between local GPU-based models (such as Wan2.1) and remote cloud APIs (such as Runway ML, Google Veo 3, Minimax, and fal.ai) through a common interface and factory pattern.
 
 This document covers the overall backend architecture, interface design, and shared utilities. For detailed information about the interface design and factory implementation, see [Architecture and Interface](05-architecture-and-interface.md). For local GPU-based generation, see [Local Generators](06-local-generators.md). For cloud API integrations, see [Remote API Generators](07-remote-api-generators.md).
 
@@ -55,16 +55,19 @@ graph TD
         runway[RunwayMLGenerator]
         veo3[Veo3Generator]
         minimax[MinimaxGenerator]
+        fal[FalGenerator]
         
         interface --> wan2
         interface --> hunyuan
         interface --> runway
         interface --> veo3
         interface --> minimax
+        interface --> fal
         
         api_cred --> runway
         api_cred --> veo3
         api_cred --> minimax
+        api_cred --> fal
     end
     
     subgraph "Utilities"
@@ -77,6 +80,7 @@ graph TD
         runway --> retry
         veo3 --> retry
         minimax --> retry
+        fal --> retry
     end
 ```
 
@@ -119,7 +123,7 @@ The configuration system supports multiple backend types with specific settings:
 
 ```yaml
 # Default backend selection
-default_backend: "wan2.1"  # Options: wan2.1, runway, veo3, auto
+default_backend: "wan2.1"  # Options: wan2.1, hunyuan, runway, veo3, minimax, fal, fal.ai, auto
 
 # Local backend configuration
 wan2_dir: "./frameworks/Wan2.1"
@@ -132,6 +136,14 @@ runway_ml:
 google_veo:
   project_id: "${GCP_PROJECT_ID}"
   credentials_path: "${GCP_CREDENTIALS_PATH}"
+
+minimax:
+  api_key: "${MINIMAX_API_KEY}"
+  model: "I2V-01-Director"
+
+fal:
+  api_key: "${FAL_API_KEY}"
+  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
 ```
 
 ### Backend Selection Logic
@@ -183,6 +195,7 @@ Cloud-based video generation services accessed via REST APIs:
 - **Runway ML**: Industry-leading video generation with models like Gen-4 Turbo
 - **Google Veo 3**: Advanced video generation with sophisticated temporal understanding
 - **Minimax**: I2V-01-Director model for image-to-video generation with camera movement control
+- **fal.ai**: Provider-backed model endpoints with flexible model selection
 
 #### Key Features
 - **Cost Efficiency**: Pay-per-use pricing without infrastructure overhead
@@ -235,7 +248,8 @@ class VideoGeneratorInterface:
 2. **Runway ML API**: Cloud-based generation via Runway ML
 3. **Google Veo 3**: Cloud-based generation via Google's Veo 3 API
 4. **Minimax API**: Cloud-based generation via Minimax
-5. **HunyuanVideo**: Local generation using the open-source HunyuanVideo model
+5. **fal.ai API**: Cloud-based generation via fal.ai model endpoints
+6. **HunyuanVideo**: Local generation using the open-source HunyuanVideo model
 
 ### Configuration Examples
 
@@ -268,6 +282,14 @@ default_backend: "minimax"
 minimax:
   api_key: "${MINIMAX_API_KEY}"
   model: "i2v-01-director"
+```
+
+**fal.ai:**
+```yaml
+default_backend: "fal"
+fal:
+  api_key: "${FAL_API_KEY}"
+  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
 ```
 
 **HunyuanVideo:**

--- a/docs/05-architecture-and-interface.md
+++ b/docs/05-architecture-and-interface.md
@@ -49,9 +49,12 @@ The `GENERATOR_REGISTRY` maps backend names to their corresponding generator cla
 ```python
 GENERATOR_REGISTRY = {
     "wan2.1": Wan21Generator,
+    "hunyuan": HunyuanVideoGenerator,
     "runway": RunwayGenerator, 
     "veo3": Veo3Generator,
-    "auto": AutoGenerator
+    "minimax": MinimaxGenerator,
+    "fal": FalGenerator,
+    "fal.ai": FalGenerator,
 }
 ```
 
@@ -82,6 +85,11 @@ The factory handles backend-specific configuration extraction, mapping general c
 - `google_veo.project_id`: GCP project identifier
 - `google_veo.credentials_path`: Path to GCP credentials
 - `google_veo.region`: GCP region for processing
+
+**fal.ai Configuration:**
+- `fal.api_key`: fal.ai API key (or `FAL_API_KEY`)
+- `fal.model`: fal model endpoint ID
+- `fal.default_input`: model-specific input defaults
 
 *Source: [`generators/factory.py`](../generators/factory.py)*
 
@@ -128,6 +136,7 @@ graph LR
     selector --> runway[runway Config]
     selector --> veo3[veo3 Config]
     selector --> minimax[minimax Config]
+    selector --> fal[fal Config]
     
     %% Wan2.1 Configuration
     wan2 --> wan2_dir[wan2_dir]
@@ -158,6 +167,12 @@ graph LR
     minimax --> minimax_model[model]
     minimax --> minimax_resolution[resolution]
     minimax --> minimax_max_duration[max_duration]
+
+    %% fal.ai Configuration
+    fal --> fal_api_key[api_key or FAL_API_KEY]
+    fal --> fal_model[model]
+    fal --> fal_base_url[base_url]
+    fal --> fal_default_input[default_input]
 ```
 
 **Configuration Mapping Logic:**

--- a/docs/07-remote-api-generators.md
+++ b/docs/07-remote-api-generators.md
@@ -9,10 +9,11 @@ This document covers the cloud-based video generation backends that interface wi
 - [`generators/remote/runway_generator.py`](../generators/remote/runway_generator.py) - Runway ML implementation
 - [`generators/remote/veo3_generator.py`](../generators/remote/veo3_generator.py) - Google Veo 3 implementation
 - [`generators/remote/minimax_generator.py`](../generators/remote/minimax_generator.py) - Minimax I2V-01-Director implementation
+- [`generators/remote/fal_generator.py`](../generators/remote/fal_generator.py) - fal.ai provider implementation with model endpoint routing
 
 ## Overview
 
-The remote API generators implement the `VideoGeneratorInterface` to provide video generation through external cloud services. Currently supported APIs include Runway ML, Google Veo 3, and Minimax I2V-01-Director. These generators handle authentication, request/response processing, polling for completion, and cost estimation while maintaining the same interface as local generators.
+The remote API generators implement the `VideoGeneratorInterface` to provide video generation through external cloud services. Currently supported APIs include Runway ML, Google Veo 3, Minimax I2V-01-Director, and fal.ai model endpoints. These generators handle authentication, request/response processing, polling for completion, and cost estimation while maintaining the same interface as local generators.
 
 **Key Features:**
 - **Unified Interface**: Same API as local generators via `VideoGeneratorInterface`
@@ -22,6 +23,30 @@ The remote API generators implement the `VideoGeneratorInterface` to provide vid
 - **Fallback Support**: Automatic switching between API providers
 
 *Sources: [`generators/remote/__init__.py`](../generators/remote/__init__.py), [`generators/remote/runway_generator.py`](../generators/remote/runway_generator.py), [`generators/remote/veo3_generator.py`](../generators/remote/veo3_generator.py), [`generators/remote/minimax_generator.py`](../generators/remote/minimax_generator.py)*
+
+## fal.ai Generator Implementation
+
+### Provider/Model Separation
+
+The `FalGenerator` treats `fal.ai` as the provider and `fal.model` as the runtime model endpoint, so one backend can target any fal-supported video model.
+
+**Configuration highlights:**
+- `default_backend`: `"fal"` or `"fal.ai"`
+- `fal.model`: full model endpoint identifier (required)
+- `fal.api_key` or environment variable `FAL_API_KEY`
+- `fal.default_input`: optional model-specific input defaults merged into each request
+
+### Header Metrics Capture
+
+When fal response headers are present, the generator captures metrics such as:
+- `x-fal-request-id`
+- `x-compute-time`
+- `x-queue-time`
+- `x-total-cost`
+- `x-request-cost`
+- `x-generation-time`
+
+Metrics are written next to the generated file as `<output>.metrics.json`.
 
 ## Architecture Overview
 
@@ -478,6 +503,16 @@ minimax:
   base_url: "https://api.minimaxi.chat/v1"
 ```
 
+**fal.ai Configuration:**
+```yaml
+fal:
+  api_key: "YOUR_FAL_API_KEY"
+  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
+  base_url: "https://fal.run"
+  max_duration: 10
+  default_input: {}
+```
+
 *Sources: [`generators/remote/runway_generator.py`](../generators/remote/runway_generator.py) (lines 39-56), [`generators/remote/veo3_generator.py`](../generators/remote/veo3_generator.py) (lines 66-82), [`generators/remote/minimax_generator.py`](../generators/remote/minimax_generator.py) (lines 66-82)*
 
 ### Environment Variable Handling
@@ -495,6 +530,9 @@ Both generators support environment variable authentication as fallbacks:
 
 **Minimax Environment Variables:**
 - **`MINIMAX_API_KEY`**: Minimax API authentication key
+
+**fal.ai Environment Variables:**
+- **`FAL_API_KEY`**: fal.ai API authentication key
 
 **Environment Variable Priority:**
 1. Configuration file values
@@ -654,6 +692,31 @@ try:
     print(f"Video generated: {video_path}")
 except Exception as e:
     print(f"Generation failed: {e}")
+```
+
+### fal.ai Generation
+
+```python
+config = {
+    "api_key": "your_fal_api_key",
+    "model": "fal-ai/minimax/hailuo-02/standard/image-to-video",
+    "base_url": "https://fal.run",
+    "timeout": 600,
+}
+
+from generators.remote.fal_generator import FalGenerator
+generator = FalGenerator(config)
+
+video_path = generator.generate_video(
+    prompt="A cinematic drone shot over neon city streets",
+    input_image_path="input.jpg",
+    output_path="output.mp4",
+    duration=5.0,
+)
+
+# Header metrics (when present) are available in:
+# - generator.last_request_metrics
+# - output.mp4.metrics.json
 ```
 
 ---

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -14,6 +14,7 @@ from generators.local.hunyuan_video_generator import HunyuanVideoGenerator
 from generators.remote.runway_generator import RunwayMLGenerator
 from generators.remote.veo3_generator import Veo3Generator
 from generators.remote.minimax_generator import MinimaxGenerator
+from generators.remote.fal_generator import FalGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,8 @@ GENERATOR_REGISTRY = {
     "runway": RunwayMLGenerator,
     "veo3": Veo3Generator,
     "minimax": MinimaxGenerator,
+    "fal": FalGenerator,
+    "fal.ai": FalGenerator,
 }
 
 
@@ -145,6 +148,31 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
             
             if not backend_config["api_key"]:
                 raise VideoGenerationError("Minimax API key is required but not provided")
+
+        elif backend in ["fal", "fal.ai"]:
+            # fal.ai configuration
+            fal_config = config.get("fal", {})
+            remote_settings = config.get("remote_api_settings", {})
+
+            backend_config = {
+                "api_key": fal_config.get("api_key"),
+                "model": fal_config.get("model"),
+                "base_url": fal_config.get("base_url", "https://fal.run"),
+                "max_duration": fal_config.get("max_duration", 10),
+                "default_input": fal_config.get("default_input", {}),
+                "max_retries": remote_settings.get("max_retries", 3),
+                "timeout": remote_settings.get("timeout", 600),
+            }
+
+            if not backend_config["model"]:
+                raise VideoGenerationError("fal.ai model is required but not provided")
+
+            if not backend_config["api_key"]:
+                import os
+                if not os.getenv("FAL_API_KEY"):
+                    raise VideoGenerationError(
+                        "fal.ai API key is required but not provided (set config fal.api_key or FAL_API_KEY)"
+                    )
         
         # Create the generator instance
         generator = generator_class(backend_config)

--- a/generators/remote/__init__.py
+++ b/generators/remote/__init__.py
@@ -2,8 +2,9 @@
 Remote API-based video generators
 """
 
+from .fal_generator import FalGenerator
+from .minimax_generator import MinimaxGenerator
 from .runway_generator import RunwayMLGenerator
 from .veo3_generator import Veo3Generator
-from .minimax_generator import MinimaxGenerator
 
-__all__ = ['RunwayMLGenerator', 'Veo3Generator', 'MinimaxGenerator']
+__all__ = ['RunwayMLGenerator', 'Veo3Generator', 'MinimaxGenerator', 'FalGenerator']

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -1,0 +1,225 @@
+"""
+fal.ai video generator implementation.
+
+This backend treats fal.ai as the provider and the model identifier as a
+runtime parameter, so the same generator can target any fal-supported model.
+"""
+
+import base64
+import json
+import os
+from typing import Any
+
+import requests
+
+from generators.base import ImageValidator, RetryHandler, download_file
+from video_generator_interface import (
+    APIError,
+    InvalidInputError,
+    VideoGenerationError,
+    VideoGeneratorInterface,
+)
+
+
+class FalGenerator(VideoGeneratorInterface):
+    """Remote video generator using fal.ai model endpoints."""
+
+    def __init__(self, config: dict[str, Any]):
+        super().__init__(config)
+        self.api_key = config.get("api_key") or os.getenv("FAL_API_KEY")
+        self.model = config.get("model")
+        self.base_url = config.get("base_url", "https://fal.run").rstrip("/")
+        self.max_duration = config.get("max_duration", 10)
+        self.timeout = config.get("timeout", 600)
+        self.max_retries = config.get("max_retries", 3)
+        self.default_input = config.get("default_input", {})
+        self.last_request_metrics: dict[str, Any] = {}
+
+        if not self.api_key:
+            raise VideoGenerationError("fal.ai API key is required (set config.fal.api_key or FAL_API_KEY)")
+        if not self.model:
+            raise VideoGenerationError("fal.ai model is required (set config.fal.model)")
+
+    def get_capabilities(self) -> dict[str, Any]:
+        return {
+            "provider": "fal.ai",
+            "model": self.model,
+            "max_duration": self.max_duration,
+            "supports_image_to_video": True,
+            "supports_text_to_video": True,
+            "requires_gpu": False,
+            "api_based": True,
+            "provider_model_separation": True,
+            "header_metrics": [
+                "x-fal-request-id",
+                "x-compute-time",
+                "x-queue-time",
+                "x-total-cost",
+                "x-request-cost",
+            ],
+        }
+
+    def estimate_cost(self, duration: float, resolution: str = "1280x720") -> float:
+        # fal cost depends on model and provider-side pricing; rely on header metrics when available.
+        return 0.0
+
+    def validate_inputs(self, prompt: str, input_image_path: str, duration: float) -> list[str]:
+        errors: list[str] = []
+
+        if not prompt or not prompt.strip():
+            errors.append("Prompt cannot be empty")
+
+        image_validation = ImageValidator.validate_image(input_image_path, max_size_mb=10.0)
+        if not image_validation["valid"]:
+            errors.extend(image_validation["errors"])
+
+        if duration <= 0:
+            errors.append("Duration must be positive")
+        elif duration > self.max_duration:
+            errors.append(f"Duration {duration}s exceeds maximum configured duration {self.max_duration}s")
+
+        return errors
+
+    def generate_video(
+        self,
+        prompt: str,
+        input_image_path: str,
+        output_path: str,
+        duration: float = 5.0,
+        **kwargs,
+    ) -> str:
+        validation_errors = self.validate_inputs(prompt, input_image_path, duration)
+        if validation_errors:
+            raise InvalidInputError(f"Input validation failed: {'; '.join(validation_errors)}")
+
+        model = kwargs.get("fal_model") or self.model
+        endpoint = f"{self.base_url}/{model.lstrip('/')}"
+
+        payload: dict[str, Any] = dict(self.default_input)
+        payload.update(kwargs.get("fal_input", {}))
+        payload.update({
+            "prompt": prompt,
+            "image_url": self._image_to_data_uri(input_image_path),
+            "duration": duration,
+        })
+
+        headers = {
+            "Authorization": f"Key {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        retry_handler = RetryHandler(max_retries=self.max_retries)
+
+        def _generate_attempt() -> str:
+            response = requests.post(endpoint, headers=headers, json=payload, timeout=self.timeout)
+
+            if response.status_code == 401:
+                raise APIError("fal.ai authentication failed", status_code=401)
+            if response.status_code == 429:
+                raise APIError("fal.ai rate limit exceeded", status_code=429)
+            if response.status_code >= 400:
+                raise APIError(
+                    f"fal.ai request failed with status {response.status_code}",
+                    status_code=response.status_code,
+                    response_body=response.text,
+                )
+
+            try:
+                response_json = response.json()
+            except json.JSONDecodeError as exc:
+                raise APIError("fal.ai returned non-JSON response") from exc
+
+            self.last_request_metrics = self._extract_response_metrics(response.headers)
+            if self.last_request_metrics:
+                self.logger.info(f"fal.ai response metrics: {self.last_request_metrics}")
+
+            video_url = self._extract_video_url(response_json)
+            download_file(video_url, output_path)
+            self._write_metrics_sidecar(output_path)
+            return output_path
+
+        return retry_handler.retry_with_backoff(_generate_attempt)
+
+    def is_available(self) -> bool:
+        return bool(self.api_key and self.model)
+
+    def _image_to_data_uri(self, image_path: str) -> str:
+        with open(image_path, "rb") as image_file:
+            data = base64.b64encode(image_file.read()).decode("utf-8")
+        mime_type = "image/png" if image_path.lower().endswith(".png") else "image/jpeg"
+        return f"data:{mime_type};base64,{data}"
+
+    def _extract_video_url(self, payload: Any) -> str:
+        url = self._find_first_url(payload)
+        if not url:
+            raise VideoGenerationError("No downloadable URL found in fal.ai response")
+        return url
+
+    def _find_first_url(self, value: Any) -> str | None:
+        if isinstance(value, dict):
+            for key in ("video", "video_url", "url", "file", "output"):
+                if key in value:
+                    result = self._find_first_url(value[key])
+                    if result:
+                        return result
+            for nested in value.values():
+                result = self._find_first_url(nested)
+                if result:
+                    return result
+            return None
+
+        if isinstance(value, list):
+            for item in value:
+                result = self._find_first_url(item)
+                if result:
+                    return result
+            return None
+
+        if isinstance(value, str) and value.startswith(("http://", "https://")):
+            return value
+        return None
+
+    def _extract_response_metrics(self, headers: dict[str, Any]) -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
+
+        request_id = headers.get("x-fal-request-id")
+        if request_id:
+            metrics["request_id"] = request_id
+
+        for header_key, metric_key in {
+            "x-compute-time": "compute_time",
+            "x-queue-time": "queue_time",
+            "x-total-cost": "total_cost",
+            "x-request-cost": "request_cost",
+            "x-generation-time": "generation_time",
+        }.items():
+            value = headers.get(header_key)
+            if value is not None:
+                metrics[metric_key] = self._parse_numeric(value)
+
+        return metrics
+
+    @staticmethod
+    def _parse_numeric(value: Any) -> Any:
+        if isinstance(value, (int, float)):
+            return value
+        if not isinstance(value, str):
+            return value
+        try:
+            if "." in value:
+                return float(value)
+            return int(value)
+        except ValueError:
+            return value
+
+    def _write_metrics_sidecar(self, output_path: str) -> None:
+        if not self.last_request_metrics:
+            return
+
+        sidecar_path = f"{output_path}.metrics.json"
+        try:
+            with open(sidecar_path, "w") as sidecar_file:
+                json.dump(self.last_request_metrics, sidecar_file, indent=2)
+        except Exception as exc:  # pragma: no cover
+            self.logger.warning(f"Failed to write fal.ai metrics sidecar: {exc}")

--- a/pipeline_config.yaml.sample
+++ b/pipeline_config.yaml.sample
@@ -16,7 +16,7 @@ prompt: >
   They place their slices next to a chalkboard drawing showing 1/2 plus 1/4 equals 3/4.
   The scene ends with Milo and Pip high-fiving, with bold on-screen text "1/2 + 1/4 = 3/4!"
 
-# Backend selection (wan2.1, runway, veo3, minimax, auto)
+# Backend selection (wan2.1, runway, veo3, minimax, fal, fal.ai, auto)
 # If set to "auto", the system will automatically select the best available backend
 default_backend: veo3
 
@@ -88,6 +88,14 @@ minimax:
   model: "I2V-01-Director"         # Minimax I2V model
   max_duration: 6                  # Maximum video duration in seconds (typical max for Minimax)
   base_url: "https://api.minimaxi.chat/v1"  # API base URL
+
+# Remote API configuration - fal.ai
+fal:
+  api_key: "YOUR_FAL_API_KEY"                 # Required unless FAL_API_KEY env var is set
+  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"  # Any fal model endpoint ID
+  base_url: "https://fal.run"                 # fal synchronous endpoint base URL
+  max_duration: 10                             # Per-request duration cap enforced by this pipeline
+  default_input: {}                            # Optional model-specific default input fields
 
 # Remote API settings (applies to all API backends)
 remote_api_settings:

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from generators.factory import create_video_generator
+from generators.remote.fal_generator import FalGenerator
+
+
+def test_extract_response_metrics_parses_cost_and_time_headers():
+    generator = FalGenerator({"api_key": "test-key", "model": "fal-ai/test-model"})
+
+    metrics = generator._extract_response_metrics(
+        {
+            "x-fal-request-id": "req_123",
+            "x-compute-time": "2.31",
+            "x-queue-time": "0.19",
+            "x-total-cost": "0.048",
+            "x-request-cost": "0.048",
+        }
+    )
+
+    assert metrics["request_id"] == "req_123"
+    assert metrics["compute_time"] == 2.31
+    assert metrics["queue_time"] == 0.19
+    assert metrics["total_cost"] == 0.048
+    assert metrics["request_cost"] == 0.048
+
+
+def test_generate_video_extracts_url_and_writes_metrics_sidecar(monkeypatch, tmp_path):
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": "fal-ai/test-model",
+            "timeout": 10,
+            "max_retries": 1,
+        }
+    )
+
+    input_image = tmp_path / "input.png"
+    input_image.write_bytes(b"image")
+    output_path = tmp_path / "output.mp4"
+
+    monkeypatch.setattr(
+        "generators.remote.fal_generator.ImageValidator.validate_image",
+        lambda *_args, **_kwargs: {"valid": True, "errors": []},
+    )
+
+    response = Mock()
+    response.status_code = 200
+    response.headers = {
+        "x-fal-request-id": "req_abc",
+        "x-compute-time": "1.2",
+        "x-total-cost": "0.01",
+    }
+    response.json.return_value = {
+        "output": {
+            "video": {
+                "url": "https://cdn.example.com/video.mp4",
+            }
+        }
+    }
+
+    monkeypatch.setattr("generators.remote.fal_generator.requests.post", lambda *args, **kwargs: response)
+
+    def _fake_download(url: str, destination: str) -> None:
+        assert url == "https://cdn.example.com/video.mp4"
+        Path(destination).write_bytes(b"video")
+
+    monkeypatch.setattr("generators.remote.fal_generator.download_file", _fake_download)
+
+    result_path = generator.generate_video(
+        prompt="test prompt",
+        input_image_path=str(input_image),
+        output_path=str(output_path),
+        duration=5,
+    )
+
+    assert result_path == str(output_path)
+    assert output_path.exists()
+    assert generator.last_request_metrics["request_id"] == "req_abc"
+    metrics_sidecar = tmp_path / "output.mp4.metrics.json"
+    assert metrics_sidecar.exists()
+    sidecar = json.loads(metrics_sidecar.read_text())
+    assert sidecar["total_cost"] == 0.01
+
+
+def test_factory_creates_fal_generator_from_provider_backend_name():
+    config = {
+        "fal": {
+            "api_key": "test-key",
+            "model": "fal-ai/test-model",
+        },
+        "remote_api_settings": {
+            "max_retries": 1,
+            "timeout": 10,
+        },
+    }
+
+    generator = create_video_generator("fal.ai", config)
+
+    assert isinstance(generator, FalGenerator)
+    assert generator.model == "fal-ai/test-model"


### PR DESCRIPTION
Introduce fal.ai as a video generation provider with explicit provider/model separation so any supported fal model endpoint can be used via configuration.

Add backend aliases (`fal`, `fal.ai`), config wiring in the factory, and support for `FAL_API_KEY` environment fallback.

Capture response header metrics (request id, timing, cost) and write them to a `<output>.metrics.json` sidecar file when available.

Add unit tests for metrics parsing, URL extraction/download flow, and factory creation, and update user/developer docs with setup and usage examples.