### PR TITLE
feat: add Veo 3.1 requested duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
 
 9.  **Generation Parameters (Applies to all video backends)**:
     *   `segment_duration_seconds`: Desired duration for each video segment in seconds (e.g., 5.0). Crucial for chaining mode.
-    *   `duration_seconds`: Optional requested final runtime for Veo 3.1. The pipeline plans 4, 6, or 8 second clips and trims only when no exact sum exists.
+    *   `duration_seconds`: Optional requested final runtime for Veo 3.1, up to 14,440 seconds. The pipeline plans 4, 6, or 8 second clips and trims only when no exact sum exists.
     *   `frame_num`, `sample_steps`, `guide_scale`, `base_seed`, etc.
 
 10.  **Output and Logging Configuration**.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
 
 4.  **Remote Backend Configuration**:
     *   `runway_ml`: Settings for Runway ML, including `api_key`, `model_version`, etc.
-    *   `google_veo`: Settings for Google Veo, including `project_id`, `credentials_path`, etc.
+    *   `google_veo`: Settings for Google Veo 3.1, including `project_id`, `credentials_path`, and optional `veo_model` (`veo-3.1-generate-001` by default or `veo-3.1-fast-generate-001`).
     *   `minimax`: Settings for Minimax API, including `api_key`, `model_version`, etc.
     *   `fal`: Settings for fal.ai, including `api_key`, `model`, optional `base_url`, and optional `default_input`.
 
@@ -153,6 +153,7 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
 
 9.  **Generation Parameters (Applies to all video backends)**:
     *   `segment_duration_seconds`: Desired duration for each video segment in seconds (e.g., 5.0). Crucial for chaining mode.
+    *   `duration_seconds`: Optional requested final runtime for Veo 3.1. The pipeline plans 4, 6, or 8 second clips and trims only when no exact sum exists.
     *   `frame_num`, `sample_steps`, `guide_scale`, `base_seed`, etc.
 
 10.  **Output and Logging Configuration**.
@@ -221,7 +222,7 @@ Remote backends (Runway, Veo3, Minimax) manage their own scaling and do not use 
 ## Usage
 
 ```bash
-uv run python pipeline.py --config pipeline_config.yaml
+uv run python pipeline.py --config pipeline_config.yaml --duration-seconds 15
 ```
 
 ## How It Works

--- a/api/config_merger.py
+++ b/api/config_merger.py
@@ -109,7 +109,8 @@ class ConfigMerger:
     def merge_for_job(
         self,
         base_config: Dict[str, Any],
-        job_prompt: str
+        job_prompt: str,
+        duration_seconds: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Merge configuration for a specific job with HTTP prompt override.
@@ -117,12 +118,16 @@ class ConfigMerger:
         Args:
             base_config: Base pipeline configuration
             job_prompt: Prompt from HTTP request
+            duration_seconds: Optional requested final runtime
             
         Returns:
             Effective configuration for the job
         """
         # HTTP prompt takes highest precedence
-        http_overrides = {'prompt': job_prompt}
+        http_overrides = {
+            'prompt': job_prompt,
+            'duration_seconds': duration_seconds,
+        }
         
         effective_config = self.build_effective_config(
             base_config=base_config,

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,7 @@ Pydantic models for API request/response validation and job management.
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, StrictInt, field_validator
 
 
 class JobStatus(str, Enum):
@@ -26,6 +26,11 @@ class JobCreateRequest(BaseModel):
         max_length=2000,
         description="Text prompt for video generation"
     )
+    duration_seconds: Optional[StrictInt] = Field(
+        None,
+        gt=0,
+        description="Requested final runtime in seconds (currently supported by Veo 3)",
+    )
     
     @field_validator('prompt')
     @classmethod
@@ -42,6 +47,7 @@ class JobCreateResponse(BaseModel):
     id: str = Field(..., description="Unique job identifier")
     status: JobStatus = Field(default=JobStatus.QUEUED, description="Initial job status")
     created_at: datetime = Field(..., description="Job creation timestamp")
+    warnings: List[str] = Field(default_factory=list, description="Generation tradeoffs")
 
 
 class JobStatusResponse(BaseModel):

--- a/api/models.py
+++ b/api/models.py
@@ -29,6 +29,7 @@ class JobCreateRequest(BaseModel):
     duration_seconds: Optional[StrictInt] = Field(
         None,
         gt=0,
+        le=14_440,
         description="Requested final runtime in seconds (currently supported by Veo 3)",
     )
     

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -49,14 +49,19 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         }
     )
 
-    from pipeline import get_duration_tradeoff
+    from pipeline import get_duration_tradeoff, get_requested_job_timeout
 
     try:
         tradeoff = get_duration_tradeoff(effective_config)
+        job_timeout = get_requested_job_timeout(effective_config)
     except ValueError as error:
         raise HTTPException(status_code=422, detail=str(error)) from error
 
-    job = job_queue.enqueue_job(request=request, effective_config=effective_config)
+    job = job_queue.enqueue_job(
+        request=request,
+        effective_config=effective_config,
+        job_timeout=job_timeout,
+    )
 
     logger.info(f"Created job {job.id} with prompt: {request.prompt[:50]}...")
 

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -23,7 +23,7 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
     """
     Create a new video generation job.
 
-    Accepts only a prompt parameter and returns immediately with a task ID.
+    Accepts a prompt and optional requested duration, then returns a task ID.
     The job is queued for processing and can be monitored via the status endpoint.
     """
     # Get job queue from app state
@@ -35,7 +35,11 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
     if not api_config or not isinstance(api_config.pipeline_config, dict):
         raise HTTPException(status_code=503, detail="Pipeline configuration not available")
 
-    effective_config = ConfigMerger().merge_for_job(api_config.pipeline_config, request.prompt)
+    effective_config = ConfigMerger().merge_for_job(
+        api_config.pipeline_config,
+        request.prompt,
+        request.duration_seconds,
+    )
     effective_config.update(
         {
             "gcs_bucket": api_config.gcs.bucket,
@@ -45,11 +49,23 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         }
     )
 
+    from pipeline import get_duration_tradeoff
+
+    try:
+        tradeoff = get_duration_tradeoff(effective_config)
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
+
     job = job_queue.enqueue_job(request=request, effective_config=effective_config)
 
     logger.info(f"Created job {job.id} with prompt: {request.prompt[:50]}...")
 
-    return JobCreateResponse(id=job.id, status=job.status, created_at=job.created_at)
+    return JobCreateResponse(
+        id=job.id,
+        status=job.status,
+        created_at=job.created_at,
+        warnings=[tradeoff] if tradeoff else [],
+    )
 
 
 @router.get("", response_model=List[JobStatusResponse])

--- a/docs/09-i2i-keyframe-generation.md
+++ b/docs/09-i2i-keyframe-generation.md
@@ -9,7 +9,7 @@ The TTV Pipeline now supports Image-to-Image (I2I) keyframe generation using Goo
 - **Character Consistency**: Maintain consistent character appearance across multiple video segments
 - **Setting Preservation**: Keep environments and backgrounds consistent throughout the video
 - **Gemini API Integration**: Leverage Google's latest Gemini models for high-quality image generation
-- **Single-Keyframe Mode**: Compatible with Veo 3's image-to-video generation (no FLF support)
+- **Remote Keyframe Mode**: Sends each segment's first and last keyframes to Veo 3.1
 - **Reference Image Support**: Use multiple reference images to guide generation
 - **Flexible Configuration**: Easily enable/disable and configure through YAML settings
 
@@ -220,7 +220,7 @@ The implementation includes comprehensive error handling:
 
 ## Limitations
 
-1. **Veo 3 Compatibility**: Currently only supports single-keyframe mode (no FLF)
+1. **Veo 3.1 Compatibility**: Supports first/last-frame generation through the remote keyframe path
 2. **API Costs**: Gemini API usage incurs costs based on token consumption
 3. **Processing Time**: I2I generation adds latency to the pipeline
 4. **Image Size**: Veo 3 requires 1024x1024 square images

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -121,6 +121,8 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
                 "credentials_path": veo_config.get("credentials_path", "credentials.json"),
                 "region": veo_config.get("region", "global"),
                 "output_bucket": veo_config.get("output_bucket"),
+                "veo_model": veo_config.get("veo_model", Veo3Generator.MODEL_NAME),
+                "video_aspect_ratio": config.get("video_aspect_ratio", "16:9"),
                 "max_retries": remote_settings.get("max_retries", 3),
                 "polling_interval": remote_settings.get("polling_interval", 15),
                 "timeout": remote_settings.get("timeout", 600),

--- a/generators/remote/veo3_generator.py
+++ b/generators/remote/veo3_generator.py
@@ -7,11 +7,8 @@ using the Google Gen AI SDK and Vertex AI.
 
 import os
 import time
-import json
-import logging
 import mimetypes
-from typing import Dict, Any, List, Optional
-from pathlib import Path
+from typing import Dict, Any, List
 
 # Google Cloud imports
 try:
@@ -34,21 +31,15 @@ except ImportError:
 
 from google.cloud import storage
 from google.oauth2 import service_account
-from PIL import Image
-
 from video_generator_interface import (
     VideoGeneratorInterface,
     VideoGenerationError,
-    APIError,
-    GenerationTimeoutError,
     InvalidInputError,
-    QuotaExceededError
 )
 from generators.base import (
     ImageValidator,
     RetryHandler,
     ProgressMonitor,
-    download_file,
     format_duration
 )
 
@@ -56,11 +47,12 @@ class Veo3Generator(VideoGeneratorInterface):
     """Remote video generator using Google Veo 3 API"""
     
     # Model name for Veo 3
-    MODEL_NAME = "veo-3.0-generate-preview"
+    MODEL_NAME = "veo-3.1-generate-001"
+    SUPPORTED_DURATIONS = [4, 6, 8]
     
     # Pricing estimates (placeholder values - actual pricing TBD)
     PRICING = {
-        "veo-3.0-generate-preview": 0.75,  # $0.10 per second (placeholder)
+        "veo-3.1-generate-001": 0.75,
     }
     
     def __init__(self, config: Dict[str, Any]):
@@ -119,8 +111,8 @@ class Veo3Generator(VideoGeneratorInterface):
     def get_capabilities(self) -> Dict[str, Any]:
         """Return Google Veo 3 capabilities"""
         return {
-            "max_duration": 5.0,  # Veo 3 currently supports up to 5 seconds
-            "supported_resolutions": ["16:9", "9:16", "1:1"],  # Aspect ratios
+            "supported_durations": self.SUPPORTED_DURATIONS,
+            "supported_resolutions": ["16:9", "9:16"],  # Aspect ratios
             "supports_image_to_video": True,
             "supports_text_to_video": False,  # Currently only image-to-video
             "requires_gpu": False,  # API-based
@@ -183,11 +175,8 @@ class Veo3Generator(VideoGeneratorInterface):
                             f"Recommended: 16:9, 9:16, or 1:1")
         
         # Validate duration
-        capabilities = self.get_capabilities()
-        if duration > capabilities["max_duration"]:
-            errors.append(f"Duration {duration}s exceeds maximum {capabilities['max_duration']}s")
-        elif duration < 1:
-            errors.append("Duration must be at least 1 second")
+        if duration not in self.SUPPORTED_DURATIONS:
+            errors.append(f"Duration must be one of {self.SUPPORTED_DURATIONS} seconds")
         
         return errors
     
@@ -195,7 +184,7 @@ class Veo3Generator(VideoGeneratorInterface):
                       prompt: str,
                       input_image_path: str,
                       output_path: str,
-                      duration: float = 5.0,
+                      duration: float = 8.0,
                       **kwargs) -> str:
         """
         Generate video using Google Veo 3 API
@@ -216,6 +205,14 @@ class Veo3Generator(VideoGeneratorInterface):
         validation_errors = self.validate_inputs(prompt, input_image_path, duration)
         if validation_errors:
             raise InvalidInputError(f"Input validation failed: {'; '.join(validation_errors)}")
+
+        last_frame_path = kwargs.get("last_frame_path")
+        if last_frame_path:
+            last_frame_validation = ImageValidator.validate_image(last_frame_path, max_size_mb=10.0)
+            if not last_frame_validation["valid"]:
+                raise InvalidInputError(
+                    f"Last frame validation failed: {'; '.join(last_frame_validation['errors'])}"
+                )
         
         # Log cost estimate
         estimated_cost = self.estimate_cost(duration)
@@ -239,19 +236,15 @@ class Veo3Generator(VideoGeneratorInterface):
             # Ensure the output bucket exists
             self._ensure_bucket_exists(self.output_bucket)
             
-            # Get the MIME type of the image
-            mime_type, _ = mimetypes.guess_type(input_image_path)
-            if not mime_type:
-                mime_type = "image/jpeg"  # Default to JPEG if can't determine
-            
-            # Upload the image to GCS if needed, or use local file
-            if kwargs.get("use_local_file", False):
-                # For local testing with direct file access
-                image = GenAIImage.from_file(input_image_path, mime_type=mime_type)
-            else:
-                # Upload to GCS and use GCS URI
-                gcs_uri = self._upload_to_gcs(input_image_path)
-                image = GenAIImage(gcs_uri=gcs_uri, mime_type=mime_type)
+            def request_image(path):
+                mime_type, _ = mimetypes.guess_type(path)
+                mime_type = mime_type or "image/jpeg"
+                if kwargs.get("use_local_file", False):
+                    return GenAIImage.from_file(location=path, mime_type=mime_type)
+                return GenAIImage(gcs_uri=self._upload_to_gcs(path), mime_type=mime_type)
+
+            image = request_image(input_image_path)
+            last_frame = request_image(last_frame_path) if last_frame_path else None
             
             # Submit the generation request
             self.logger.info(f"Submitting video generation request to {self.model_name}...")
@@ -259,7 +252,9 @@ class Veo3Generator(VideoGeneratorInterface):
             # Create the configuration
             config = GenerateVideosConfig(
                 aspect_ratio=video_aspect_ratio,
-                output_gcs_uri=output_gcs_uri
+                duration_seconds=int(duration),
+                last_frame=last_frame,
+                output_gcs_uri=output_gcs_uri,
             )
             
             # Use the asynchronous API call and wait for completion

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -266,6 +266,11 @@ components:
           maxLength: 2000
           description: Text prompt for video generation
           example: "A cat playing with a ball of yarn in a sunny garden"
+        duration_seconds:
+          type: integer
+          minimum: 1
+          nullable: true
+          description: Requested final runtime in seconds (currently supported by Veo 3)
 
     JobCreateResponse:
       type: object
@@ -284,6 +289,11 @@ components:
           type: string
           format: date-time
           description: Job creation timestamp
+        warnings:
+          type: array
+          items:
+            type: string
+          description: Generation tradeoffs, including final-frame loss when a Veo clip must be trimmed
 
     JobStatusResponse:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -269,6 +269,7 @@ components:
         duration_seconds:
           type: integer
           minimum: 1
+          maximum: 14440
           nullable: true
           description: Requested final runtime in seconds (currently supported by Veo 3)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -199,6 +199,18 @@ def get_video_generation_backend(config: Dict) -> str:
     return str(default_backend).lower()
 
 
+def get_provider_compatible_duration(
+    config: Dict,
+    primary_backend: str,
+    attempt_backend: str,
+    planned_duration: float,
+) -> float:
+    """Use generic clip duration when a non-Veo backend replaces Veo."""
+    if str(primary_backend).lower() == "veo3" and str(attempt_backend).lower() != "veo3":
+        return config.get("segment_duration_seconds", 5.0)
+    return planned_duration
+
+
 def resolve_frame_reference(frame_ref: Optional[str], frames_dir: str) -> Optional[str]:
     """Resolve a prompt frame reference within the output frames directory."""
     if not frame_ref:
@@ -1023,13 +1035,11 @@ def generate_video_segments_single_keyframe(
             fallback_generator = factory.get_fallback_generator(backend, config)
             if fallback_generator:
                 logging.info(f"Trying fallback generator for segment {seg}")
-                fallback_backend = str(
-                    config.get("remote_api_settings", {}).get("fallback_backend", "")
-                ).lower()
-                fallback_duration = (
-                    config.get("segment_duration_seconds", 5.0)
-                    if backend == "veo3" and fallback_backend != "veo3"
-                    else segment_duration
+                fallback_duration = get_provider_compatible_duration(
+                    config,
+                    backend,
+                    fallback_generator.get_backend_name(),
+                    segment_duration,
                 )
                 fallback_generator.generate_video(
                     prompt=prompt_text,
@@ -1392,12 +1402,19 @@ def generate_video_chaining_mode(
 
         while attempt_generator:
             try:
-                logging.info(f"Attempting segment {seg} with {attempt_generator.get_backend_name()}...")
+                attempt_backend_name = attempt_generator.get_backend_name()
+                attempt_duration = get_provider_compatible_duration(
+                    config,
+                    config.get("default_backend", "wan2.1"),
+                    attempt_backend_name,
+                    item_duration,
+                )
+                logging.info(f"Attempting segment {seg} with {attempt_backend_name}...")
 
                 validation_errors = attempt_generator.validate_inputs(
                     prompt=prompt_text,
                     input_image_path=input_image,
-                    duration=item_duration
+                    duration=attempt_duration
                 )
                 if validation_errors:
                     logging.error(f"Input validation failed for segment {seg} with {attempt_generator.get_backend_name()}: {validation_errors}")
@@ -1407,7 +1424,7 @@ def generate_video_chaining_mode(
                     prompt=prompt_text,
                     input_image_path=input_image,
                     output_path=video_file_output_path,
-                    duration=item_duration,
+                    duration=attempt_duration,
                     frame_num=config.get("frame_num", 81) # Pass frame_num from main config if available
                 )
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -205,9 +205,18 @@ def get_provider_compatible_duration(
     attempt_backend: str,
     planned_duration: float,
 ) -> float:
-    """Use generic clip duration when a non-Veo backend replaces Veo."""
+    """Map fallback attempts to the receiving provider's duration contract."""
     if str(primary_backend).lower() == "veo3" and str(attempt_backend).lower() != "veo3":
         return config.get("segment_duration_seconds", 5.0)
+    if str(attempt_backend).lower() == "veo3" and planned_duration not in VEO_CLIP_DURATIONS:
+        return next(
+            (
+                duration
+                for duration in VEO_CLIP_DURATIONS
+                if duration >= planned_duration
+            ),
+            VEO_CLIP_DURATIONS[-1],
+        )
     return planned_duration
 
 
@@ -308,6 +317,9 @@ def build_prompt_enhancement_instructions(config: Dict) -> str:
     if backend == "minimax":
         instructions += "\n\nIMPORTANT: Each Minimax video prompt must be 500 characters or less."
     elif backend == "veo3":
+        instructions = instructions.replace(
+            '"total_duration_seconds": 10', '"total_duration_seconds": 8'
+        ).replace('"duration_seconds": 5', '"duration_seconds": 4')
         instructions += "\n\nIMPORTANT: Each Veo video prompt must be 1000 characters or less."
         plan = get_requested_segment_plan(config)
         if plan:

--- a/pipeline.py
+++ b/pipeline.py
@@ -82,6 +82,7 @@ class VideoPrompt(BaseModel):
     prompt: str
     first_frame: Optional[str] = None
     last_frame: Optional[str] = None
+    duration_seconds: Optional[int] = None
 
 class PromptEnhancementResult(BaseModel):
     segmentation_logic: SegmentationLogic
@@ -90,7 +91,7 @@ class PromptEnhancementResult(BaseModel):
 
 # Instructions for prompt splitting and enhancement
 PROMPT_ENHANCEMENT_INSTRUCTIONS = """
-Split and enhance an input text-to-video prompt and starting reference image into detailed, standalone prompts for 5-second video segments. This requires narrative pacing, descriptive clarity, cinematic knowledge, and continuity skills.
+Split and enhance an input text-to-video prompt and starting reference image into detailed, standalone prompts for video segments. This requires narrative pacing, descriptive clarity, cinematic knowledge, and continuity skills.
 
 Analyze the Input Prompt and Starting Reference Image
 - Prompt Analysis: Identify the setting, characters, actions, camera movements, and style (e.g., mood, lighting).
@@ -99,7 +100,7 @@ Analyze the Input Prompt and Starting Reference Image
 
 Determine Duration and Segmentation
 - Estimate the total duration based on the complexity and pacing of actions.
-- Divide into 5-second segments, each with distinct start and end actions.
+- Unless backend-specific duration requirements are appended below, divide into 5-second segments, each with distinct start and end actions.
 - Balance the narrative flow across segments for a cohesive story.
 
 Enhance Prompt Specificity
@@ -122,7 +123,7 @@ Generate Keyframe Prompts
 - Each keyframe prompt generates an image (e.g., `segment_01.png`) that becomes the last frame of its segment and the first frame of the next segment.
 
 Generate Video Prompts
-- Write text-to-video prompts for each 5-second segment.
+- Write one text-to-video prompt for each segment.
 - Detail actions, camera movements, and style.
 - Reference the first frame (`provided_start_image.png` for segment 1, `segment_XX.png` for others) and last frame (`segment_YY.png`).
 - Ensure each prompt is standalone with full context.
@@ -177,6 +178,117 @@ Expected Output (JSON):
 Respond ONLY with the JSON response formatted as above, with NO wrapper or commentary.
 """
 
+VEO_CLIP_DURATIONS = (4, 6, 8)
+
+
+def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
+    """Return the shortest Veo-compatible plan covering the requested runtime."""
+    if (
+        isinstance(duration_seconds, bool)
+        or not isinstance(duration_seconds, int)
+        or duration_seconds <= 0
+    ):
+        raise ValueError("duration_seconds must be a positive integer")
+
+    planned_total = max(4, duration_seconds + duration_seconds % 2)
+    eights, remainder = divmod(planned_total, 8)
+    if remainder == 0:
+        return [8] * eights
+    if remainder == 2:
+        return [8] * (eights - 1) + [4, 6]
+    return [8] * eights + [remainder]
+
+
+def get_requested_segment_plan(config: Dict) -> Optional[List[int]]:
+    """Build the current provider's segment plan when final duration is requested."""
+    requested = config.get("duration_seconds")
+    if requested is None:
+        return None
+    if (
+        isinstance(requested, bool)
+        or not isinstance(requested, (int, float))
+        or int(requested) != requested
+    ):
+        raise ValueError("duration_seconds must be a positive integer")
+    if config.get("default_backend", "wan2.1").lower() != "veo3":
+        raise ValueError("duration_seconds is currently supported only for the veo3 backend")
+    return plan_veo_segment_durations(int(requested))
+
+
+def get_duration_tradeoff(config: Dict) -> Optional[str]:
+    """Explain when exact runtime trimming removes the final generated keyframe."""
+    plan = get_requested_segment_plan(config)
+    requested = config.get("duration_seconds")
+    if plan and sum(plan) > requested:
+        return (
+            f"Requested {requested}s cannot be composed exactly from Veo clips {list(VEO_CLIP_DURATIONS)}; "
+            f"the {sum(plan)}s plan will be trimmed, so the final clip's ending keyframe will not appear."
+        )
+    return None
+
+
+def get_trim_duration_seconds(config: Dict) -> Optional[int]:
+    """Return the requested final runtime only when the provider plan must be trimmed."""
+    return int(config["duration_seconds"]) if get_duration_tradeoff(config) else None
+
+
+def build_prompt_enhancement_instructions(config: Dict) -> str:
+    """Add only the active backend's prompt and duration constraints."""
+    backend = config.get("default_backend", "wan2.1").lower()
+    instructions = PROMPT_ENHANCEMENT_INSTRUCTIONS
+    if backend == "minimax":
+        instructions += "\n\nIMPORTANT: Each Minimax video prompt must be 500 characters or less."
+    elif backend == "veo3":
+        instructions += "\n\nIMPORTANT: Each Veo video prompt must be 1000 characters or less."
+        plan = get_requested_segment_plan(config)
+        if plan:
+            requested = int(config["duration_seconds"])
+            instructions += (
+                f"\nThe requested final runtime is exactly {requested} seconds. Return exactly {len(plan)} segments "
+                f"with duration_seconds values {plan} in order. Set segmentation_logic.total_duration_seconds "
+                f"to {requested} and number_of_segments to {len(plan)}."
+            )
+            tradeoff = get_duration_tradeoff(config)
+            if tradeoff:
+                instructions += f"\n{tradeoff}"
+        else:
+            instructions += (
+                f"\nInfer the final runtime and segment count. Every video_prompt must include duration_seconds "
+                f"as one of {list(VEO_CLIP_DURATIONS)}, and segmentation_logic.total_duration_seconds must equal "
+                "the sum of those durations."
+            )
+    return instructions
+
+
+def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
+    """Reject an LLM decomposition that does not match the provider duration plan."""
+    if config.get("default_backend", "wan2.1").lower() != "veo3":
+        return
+
+    video_prompts = result["video_prompts"]
+    keyframe_prompts = result["keyframe_prompts"]
+    segmentation = result["segmentation_logic"]
+    segment_numbers = list(range(1, len(video_prompts) + 1))
+    durations = [item.get("duration_seconds") for item in video_prompts]
+    expected = get_requested_segment_plan(config)
+
+    if [item.get("segment") for item in video_prompts] != segment_numbers:
+        raise ValueError("LLM video segments are not sequential")
+    if [item.get("segment") for item in keyframe_prompts] != segment_numbers:
+        raise ValueError("LLM keyframe segments do not match the video segments")
+    if segmentation.get("number_of_segments") != len(video_prompts):
+        raise ValueError("LLM segment count does not match its prompts")
+    if expected and durations != expected:
+        raise ValueError(f"LLM durations {durations} do not match requested segment plan {expected}")
+    if not expected and any(duration not in VEO_CLIP_DURATIONS for duration in durations):
+        raise ValueError(f"LLM durations must use Veo values {list(VEO_CLIP_DURATIONS)}")
+
+    expected_total = int(config["duration_seconds"]) if expected else sum(durations)
+    if segmentation.get("total_duration_seconds") != expected_total:
+        raise ValueError(
+            f"LLM total duration {segmentation.get('total_duration_seconds')} does not match {expected_total}"
+        )
+
 class PromptEnhancer:
     """Uses OpenAI to enhance prompts with structured output validation via instructor"""
 
@@ -205,6 +317,21 @@ class PromptEnhancer:
             raise
 
         return result.dict()
+
+
+def enhance_prompt_data(prompt: str, config: Dict) -> Dict:
+    """Enhance and validate a prompt using the effective pipeline configuration."""
+    enhancer = PromptEnhancer(
+        api_key=config.get("openai_api_key"),
+        base_url=config.get("openai_base_url", "https://api.openai.com/v1"),
+        model=config.get("prompt_enhancement_model", "gpt-4o-mini"),
+    )
+    result = enhancer.enhance(build_prompt_enhancement_instructions(config), prompt)
+    validate_prompt_enhancement(result, config)
+    tradeoff = get_duration_tradeoff(config)
+    if tradeoff:
+        logging.warning(tradeoff)
+    return result
 
 # ============================================================================
 # Pipeline Components
@@ -366,7 +493,11 @@ def prepare_keyframes(
     return keyframe_paths
 
 
-def stitch_video_segments(video_paths: List[str], output_file: str) -> Optional[str]:
+def stitch_video_segments(
+    video_paths: List[str],
+    output_file: str,
+    trim_duration_seconds: Optional[int] = None,
+) -> Optional[str]:
     """Stitch together video segments into a final video using ffmpeg"""
     if not video_paths:
         logging.warning("No video paths provided for stitching")
@@ -379,8 +510,16 @@ def stitch_video_segments(video_paths: List[str], output_file: str) -> Optional[
         list_file = f.name
 
     # Use ffmpeg to concatenate the segments
-    cmd = ["ffmpeg", "-f", "concat", "-safe", "0",
-        "-i", list_file, "-c", "copy", output_file, "-y"]
+    cmd = ["ffmpeg", "-f", "concat", "-safe", "0", "-i", list_file]
+    if trim_duration_seconds is not None:
+        cmd.extend([
+            "-t", str(trim_duration_seconds),
+            "-c:v", "libx264",
+            "-c:a", "aac",
+        ])
+    else:
+        cmd.extend(["-c", "copy"])
+    cmd.extend([output_file, "-y"])
     run_command(cmd)
 
     # Clean up the temporary file
@@ -408,7 +547,7 @@ def generate_single_video_segment(
         flf2v_model_dir: Path to the FLF2V model directory
         frame_num: Number of frames to generate
         gpu_ids: List of GPU IDs to use for this segment generation
-        single_keyframe_mode: If True, use single keyframe for I2V generation (for Veo3)
+        single_keyframe_mode: If True, use the remote keyframe generation path (for Veo3)
 
     Returns:
         Path to the generated video file
@@ -670,7 +809,7 @@ def generate_video_segments_single_keyframe(
     output_dir: str
 ) -> List[str]:
     """
-    Generate video segments using single keyframe for I2V generation (e.g., Veo3).
+    Generate video segments through remote keyframe APIs (e.g., Veo3 first/last frame).
 
     Args:
         config: Configuration dictionary
@@ -686,9 +825,6 @@ def generate_video_segments_single_keyframe(
     # Get the video generation backend
     backend = config.get('default_video_generation_backend', config.get('default_backend', 'veo3'))
     logging.info(f"Using {backend} for single-keyframe video generation")
-
-    # Get segment duration
-    segment_duration = config.get('segment_duration_seconds', 5.0)
 
     # Get I2I mode configuration
     i2i_config = config.get('i2i_mode', {})
@@ -708,6 +844,10 @@ def generate_video_segments_single_keyframe(
 
     for prompt_item in video_prompts:
         seg, prompt_text = prompt_item["segment"], prompt_item["prompt"]
+        segment_duration = prompt_item.get(
+            "duration_seconds", config.get("segment_duration_seconds", 5.0)
+        )
+        last_frame_path = prompt_item.get("last_frame")
 
         # Select the keyframe based on position setting
         if keyframe_position == 'first' and 'first_frame' in prompt_item:
@@ -749,7 +889,8 @@ def generate_video_segments_single_keyframe(
                 prompt=prompt_text,
                 input_image_path=keyframe_path,
                 output_path=video_file,
-                duration=segment_duration
+                duration=segment_duration,
+                last_frame_path=last_frame_path,
             )
 
             video_paths.append(video_file)
@@ -766,7 +907,8 @@ def generate_video_segments_single_keyframe(
                     prompt=prompt_text,
                     input_image_path=keyframe_path,
                     output_path=video_file,
-                    duration=segment_duration
+                    duration=segment_duration,
+                    last_frame_path=last_frame_path,
                 )
                 video_paths.append(video_file)
                 logging.info(f"Fallback succeeded for segment {seg}")
@@ -915,85 +1057,24 @@ def enhance_prompt(prompt: str, config: Dict, output_dir: str) -> Dict:
 
     logging.info("Enhancing input prompt...")
 
-    # Extract configuration
-    api_key = config.get("openai_api_key")
-    base_url = config.get("openai_base_url")
-    model = config.get("prompt_enhancement_model", "gpt-4o-mini")
-    default_backend = config.get("default_backend", "wan2.1")
-
-    if not api_key:
+    if not config.get("openai_api_key"):
         logging.warning("No OpenAI API key provided, skipping prompt enhancement")
         return {"keyframe_prompts": [], "video_prompts": []}
 
-    # Check if using Minimax or Veo3 backend to add character limit constraint
-    backend_constraint = ""
-    if default_backend.lower() == "minimax":
-        backend_constraint = "\n\nIMPORTANT: When generating video prompts for Minimax backend, each video prompt must be 500 characters or less. Keep descriptions concise and focused while maintaining essential visual and action details."
-    elif default_backend.lower() == "veo3":
-        backend_constraint = "\n\nIMPORTANT: When generating video prompts for Veo3 backend, each video prompt must be 1000 characters or less. Keep descriptions concise and focused while maintaining essential visual and action details."
-
     try:
-        # Set up the OpenAI client
-        from openai import OpenAI
-        from instructor import from_openai, Mode
-
-        client_kwargs = {"api_key": api_key}
-        if base_url:
-            client_kwargs["base_url"] = base_url
-
-        client = OpenAI(**client_kwargs)
-        instructor_client = from_openai(client, mode=Mode.TOOLS)
-
-        # Define the messages with potential backend constraint
-        messages = [
-            {"role": "system", "content": PROMPT_ENHANCEMENT_INSTRUCTIONS + backend_constraint},
-            {"role": "user", "content": prompt}
-        ]
-
-        # Get enhanced prompts
-        logging.info(f"Making request to OpenAI API with model: {model}")
-
-        # Basic parameters that all models support
-        completion_params = {
-            "model": model,
-            "response_model": PromptEnhancementResult,
-            "messages": messages
-        }
-
-        # Only add temperature if not using o4-mini or gpt-5 (which don't support custom temperature)
-        if not (model.startswith("o4-mini") or "gpt-5" in model):
-            completion_params["temperature"] = 0.7
-            completion_params["seed"] = 42
-            logging.info(f"Using temperature=0.7 and seed=42 with model {model}")
-        else:
-            logging.info(f"Using default parameters for model {model} (no temperature/seed)")
-
-        # Make the API call with appropriate parameters
-        result = instructor_client.chat.completions.create(**completion_params)
-
-        # Convert to dict format
-        if hasattr(result, 'model_dump'):
-            result_dict = result.model_dump()
-        else:
-            result_dict = result.dict()
-
-        # The response is already in the right structure, add debugging output
-        print(f"DEBUG - Response keys: {result_dict.keys()}")
-
-        # Create a copy of the result to modify as needed
-        enhanced_data = result_dict
+        enhanced_data = enhance_prompt_data(prompt, config)
 
         # Display the enhanced segmented prompts in colors
         print(f"\n{Colors.BOLD}{Colors.PURPLE}Enhanced Prompt Segments:{Colors.RESET}")
 
         # Get the segment count from the segmentation logic
-        num_segments = result_dict["segmentation_logic"]["number_of_segments"]
+        num_segments = enhanced_data["segmentation_logic"]["number_of_segments"]
         print(f"DEBUG - Number of segments: {num_segments}")
 
         # Create formatted output for each segment
-        for i in range(len(result_dict["keyframe_prompts"])):
-            keyframe_info = result_dict["keyframe_prompts"][i]
-            video_info = result_dict["video_prompts"][i]
+        for i in range(len(enhanced_data["keyframe_prompts"])):
+            keyframe_info = enhanced_data["keyframe_prompts"][i]
+            video_info = enhanced_data["video_prompts"][i]
 
             segment_num = keyframe_info["segment"]
             keyframe_prompt = keyframe_info["prompt"]
@@ -1074,6 +1155,7 @@ def generate_video_chaining_mode(
 
     for idx, item in enumerate(video_prompts):
         seg, prompt_text = item["segment"], item["prompt"]
+        item_duration = item.get("duration_seconds", segment_duration)
 
         logging.info(f"Processing segment {seg}/{len(video_prompts)} in chaining mode")
 
@@ -1187,7 +1269,7 @@ def generate_video_chaining_mode(
                 validation_errors = attempt_generator.validate_inputs(
                     prompt=prompt_text,
                     input_image_path=input_image,
-                    duration=segment_duration
+                    duration=item_duration
                 )
                 if validation_errors:
                     logging.error(f"Input validation failed for segment {seg} with {attempt_generator.get_backend_name()}: {validation_errors}")
@@ -1197,7 +1279,7 @@ def generate_video_chaining_mode(
                     prompt=prompt_text,
                     input_image_path=input_image,
                     output_path=video_file_output_path,
-                    duration=segment_duration,
+                    duration=item_duration,
                     frame_num=config.get("frame_num", 81) # Pass frame_num from main config if available
                 )
 
@@ -1249,14 +1331,21 @@ def generate_video_chaining_mode(
 # Main Pipeline Function
 # ============================================================================
 
-def run_pipeline(config_path: str, prompt_override: str = None) -> None:
+def run_pipeline(
+    config_path: str,
+    prompt_override: str = None,
+    duration_seconds: Optional[int] = None,
+) -> None:
     """Run the end-to-end pipeline using configuration from YAML"""
     logging.info(f"Loading configuration from {config_path}")
     base_config = load_config(config_path)
 
     # Use ConfigMerger to handle prompt override with proper precedence
     config_merger = ConfigMerger()
-    cli_args = {'prompt': prompt_override} if prompt_override else None
+    cli_args = {
+        "prompt": prompt_override,
+        "duration_seconds": duration_seconds,
+    }
     
     # Build effective configuration with CLI prompt override
     config = config_merger.build_effective_config(
@@ -1378,10 +1467,11 @@ def run_pipeline(config_path: str, prompt_override: str = None) -> None:
         logging.info(f"Video segment {i+1}: {path}")
 
     # Stitch video segments together if we have more than one
-    if len(video_paths) > 1:
+    trim_duration = get_trim_duration_seconds(config)
+    if len(video_paths) > 1 or trim_duration is not None:
         logging.info("Stitching video segments together...")
         final_output = os.path.join(output_dir, "final_video.mp4")
-        stitched_video = stitch_video_segments(video_paths, final_output)
+        stitched_video = stitch_video_segments(video_paths, final_output, trim_duration)
         if stitched_video:
             logging.info(f"Final stitched video saved to: {final_output}")
         else:
@@ -1404,9 +1494,14 @@ def main():
                        help='Path to the pipeline configuration file')
     parser.add_argument('--prompt', type=str,
                        help='Override the prompt from the config file')
+    parser.add_argument(
+        '--duration-seconds',
+        type=int,
+        help='Requested final runtime in seconds (currently supported by Veo 3)',
+    )
 
     args = parser.parse_args()
-    run_pipeline(args.config, args.prompt)
+    run_pipeline(args.config, args.prompt, args.duration_seconds)
 
 if __name__ == "__main__":
     main()

--- a/pipeline.py
+++ b/pipeline.py
@@ -179,6 +179,15 @@ Respond ONLY with the JSON response formatted as above, with NO wrapper or comme
 """
 
 VEO_CLIP_DURATIONS = (4, 6, 8)
+MAX_REQUESTED_DURATION_SECONDS = 14_440
+
+
+def get_video_generation_backend(config: Dict) -> str:
+    """Return the backend used for video generation."""
+    return str(
+        config.get("default_video_generation_backend")
+        or config.get("default_backend", "wan2.1")
+    ).lower()
 
 
 def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
@@ -189,6 +198,10 @@ def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
         or duration_seconds <= 0
     ):
         raise ValueError("duration_seconds must be a positive integer")
+    if duration_seconds > MAX_REQUESTED_DURATION_SECONDS:
+        raise ValueError(
+            f"duration_seconds must be at most {MAX_REQUESTED_DURATION_SECONDS}"
+        )
 
     planned_total = max(4, duration_seconds + duration_seconds % 2)
     eights, remainder = divmod(planned_total, 8)
@@ -210,7 +223,7 @@ def get_requested_segment_plan(config: Dict) -> Optional[List[int]]:
         or int(requested) != requested
     ):
         raise ValueError("duration_seconds must be a positive integer")
-    if config.get("default_backend", "wan2.1").lower() != "veo3":
+    if get_video_generation_backend(config) != "veo3":
         raise ValueError("duration_seconds is currently supported only for the veo3 backend")
     return plan_veo_segment_durations(int(requested))
 
@@ -234,7 +247,7 @@ def get_trim_duration_seconds(config: Dict) -> Optional[int]:
 
 def build_prompt_enhancement_instructions(config: Dict) -> str:
     """Add only the active backend's prompt and duration constraints."""
-    backend = config.get("default_backend", "wan2.1").lower()
+    backend = get_video_generation_backend(config)
     instructions = PROMPT_ENHANCEMENT_INSTRUCTIONS
     if backend == "minimax":
         instructions += "\n\nIMPORTANT: Each Minimax video prompt must be 500 characters or less."
@@ -262,7 +275,7 @@ def build_prompt_enhancement_instructions(config: Dict) -> str:
 
 def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
     """Reject an LLM decomposition that does not match the provider duration plan."""
-    if config.get("default_backend", "wan2.1").lower() != "veo3":
+    if get_video_generation_backend(config) != "veo3":
         return
 
     video_prompts = result["video_prompts"]
@@ -278,6 +291,11 @@ def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
         raise ValueError("LLM keyframe segments do not match the video segments")
     if segmentation.get("number_of_segments") != len(video_prompts):
         raise ValueError("LLM segment count does not match its prompts")
+    if any(
+        not item.get("first_frame") or not item.get("last_frame")
+        for item in video_prompts
+    ):
+        raise ValueError("LLM Veo segments must include first_frame and last_frame")
     if expected and durations != expected:
         raise ValueError(f"LLM durations {durations} do not match requested segment plan {expected}")
     if not expected and any(duration not in VEO_CLIP_DURATIONS for duration in durations):
@@ -823,7 +841,7 @@ def generate_video_segments_single_keyframe(
     video_paths = []
 
     # Get the video generation backend
-    backend = config.get('default_video_generation_backend', config.get('default_backend', 'veo3'))
+    backend = get_video_generation_backend(config)
     logging.info(f"Using {backend} for single-keyframe video generation")
 
     # Get I2I mode configuration
@@ -849,8 +867,10 @@ def generate_video_segments_single_keyframe(
         )
         last_frame_path = prompt_item.get("last_frame")
 
-        # Select the keyframe based on position setting
-        if keyframe_position == 'first' and 'first_frame' in prompt_item:
+        # Veo first/last-frame generation always starts from the first frame.
+        if backend == 'veo3':
+            keyframe_path = prompt_item.get('first_frame')
+        elif keyframe_position == 'first' and 'first_frame' in prompt_item:
             keyframe_path = prompt_item['first_frame']
         elif keyframe_position == 'last' and 'last_frame' in prompt_item:
             keyframe_path = prompt_item['last_frame']
@@ -898,6 +918,9 @@ def generate_video_segments_single_keyframe(
 
         except VideoGenerationError as e:
             logging.error(f"Failed to generate video for segment {seg}: {e}")
+
+            if config.get("duration_seconds") is not None:
+                raise
 
             # Try fallback if configured
             fallback_generator = factory.get_fallback_generator(backend, config)
@@ -1354,6 +1377,9 @@ def run_pipeline(
         http_overrides=None  # No HTTP overrides in CLI context
     )
 
+    # Reject unsupported or excessive requests before any generation work.
+    get_requested_segment_plan(config)
+
     base_dir = os.getcwd()  # Current working directory
     output_dir = os.path.join(base_dir, "output")
     frames_dir = os.path.join(output_dir, "frames")
@@ -1497,7 +1523,10 @@ def main():
     parser.add_argument(
         '--duration-seconds',
         type=int,
-        help='Requested final runtime in seconds (currently supported by Veo 3)',
+        help=(
+            'Requested final runtime in seconds '
+            f'(Veo 3 only; max {MAX_REQUESTED_DURATION_SECONDS})'
+        ),
     )
 
     args = parser.parse_args()

--- a/pipeline.py
+++ b/pipeline.py
@@ -248,9 +248,28 @@ def get_requested_segment_plan(config: Dict) -> Optional[List[int]]:
         or int(requested) != requested
     ):
         raise ValueError("duration_seconds must be a positive integer")
+    if (
+        str(config.get("generation_mode", "keyframe")).lower() != "keyframe"
+        or not config.get("single_keyframe_mode", False)
+    ):
+        raise ValueError(
+            "duration_seconds requires generation_mode=keyframe and "
+            "single_keyframe_mode=true"
+        )
     if get_video_generation_backend(config) != "veo3":
         raise ValueError("duration_seconds is currently supported only for the veo3 backend")
     return plan_veo_segment_durations(int(requested))
+
+
+def get_requested_job_timeout(config: Dict) -> int:
+    """Allow enough queue time for every planned Veo request plus pipeline overhead."""
+    plan = get_requested_segment_plan(config)
+    if not plan:
+        return 3600
+    provider_timeout = max(
+        600, int(config.get("remote_api_settings", {}).get("timeout", 600))
+    )
+    return 3600 + len(plan) * provider_timeout
 
 
 def get_duration_tradeoff(config: Dict) -> Optional[str]:

--- a/pipeline.py
+++ b/pipeline.py
@@ -82,7 +82,7 @@ class VideoPrompt(BaseModel):
     prompt: str
     first_frame: Optional[str] = None
     last_frame: Optional[str] = None
-    duration_seconds: Optional[int] = None
+    duration_seconds: int
 
 class PromptEnhancementResult(BaseModel):
     segmentation_logic: SegmentationLogic
@@ -125,6 +125,7 @@ Generate Keyframe Prompts
 Generate Video Prompts
 - Write one text-to-video prompt for each segment.
 - Detail actions, camera movements, and style.
+- Include `duration_seconds` for every video prompt; use 5 unless backend-specific requirements say otherwise.
 - Reference the first frame (`provided_start_image.png` for segment 1, `segment_XX.png` for others) and last frame (`segment_YY.png`).
 - Ensure each prompt is standalone with full context.
 
@@ -164,13 +165,15 @@ Expected Output (JSON):
       "segment": 1,
       "prompt": "The camera tracks behind a woman in a red dress as she begins running across a rainy street at night, cinematic lighting, streetlights reflecting on wet pavement, rendered in a realistic style.",
       "first_frame": "provided_start_image.png",
-      "last_frame": "segment_01.png"
+      "last_frame": "segment_01.png",
+      "duration_seconds": 5
     },
     {
       "segment": 2,
       "prompt": "The camera continues tracking behind the woman in a red dress as she completes her run across the rainy street at night, cinematic lighting, streetlights reflecting on wet pavement, rendered in a realistic style.",
       "first_frame": "segment_01.png",
-      "last_frame": "segment_02.png"
+      "last_frame": "segment_02.png",
+      "duration_seconds": 5
     }
   ]
 }
@@ -180,14 +183,36 @@ Respond ONLY with the JSON response formatted as above, with NO wrapper or comme
 
 VEO_CLIP_DURATIONS = (4, 6, 8)
 MAX_REQUESTED_DURATION_SECONDS = 14_440
+MAX_PROMPT_SEGMENTS_PER_CALL = 20
 
 
 def get_video_generation_backend(config: Dict) -> str:
     """Return the backend used for video generation."""
-    return str(
-        config.get("default_video_generation_backend")
-        or config.get("default_backend", "wan2.1")
-    ).lower()
+    default_backend = config.get("default_backend", "wan2.1")
+    if (
+        str(config.get("generation_mode", "keyframe")).lower() == "keyframe"
+        and config.get("single_keyframe_mode", False)
+    ):
+        return str(
+            config.get("default_video_generation_backend") or default_backend
+        ).lower()
+    return str(default_backend).lower()
+
+
+def resolve_frame_reference(frame_ref: Optional[str], frames_dir: str) -> Optional[str]:
+    """Resolve a prompt frame reference within the output frames directory."""
+    if not frame_ref:
+        return None
+    if frame_ref == "provided_start_image.png":
+        frame_ref = "segment_00.png"
+    if os.path.isabs(frame_ref):
+        return os.path.abspath(frame_ref)
+
+    frames_dir = os.path.abspath(frames_dir)
+    frame_path = os.path.abspath(os.path.join(frames_dir, frame_ref))
+    if os.path.commonpath((frames_dir, frame_path)) != frames_dir:
+        raise ValueError(f"Invalid frame path: {frame_ref}")
+    return frame_path
 
 
 def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
@@ -344,7 +369,75 @@ def enhance_prompt_data(prompt: str, config: Dict) -> Dict:
         base_url=config.get("openai_base_url", "https://api.openai.com/v1"),
         model=config.get("prompt_enhancement_model", "gpt-4o-mini"),
     )
-    result = enhancer.enhance(build_prompt_enhancement_instructions(config), prompt)
+    plan = get_requested_segment_plan(config)
+    if not plan or len(plan) <= MAX_PROMPT_SEGMENTS_PER_CALL:
+        result = enhancer.enhance(build_prompt_enhancement_instructions(config), prompt)
+    else:
+        keyframe_prompts = []
+        video_prompts = []
+        reasonings = []
+        batch_count = (
+            len(plan) + MAX_PROMPT_SEGMENTS_PER_CALL - 1
+        ) // MAX_PROMPT_SEGMENTS_PER_CALL
+
+        for batch_index, offset in enumerate(
+            range(0, len(plan), MAX_PROMPT_SEGMENTS_PER_CALL), start=1
+        ):
+            batch_plan = plan[offset:offset + MAX_PROMPT_SEGMENTS_PER_CALL]
+            batch_config = {**config, "duration_seconds": sum(batch_plan)}
+            first_segment = offset + 1
+            last_segment = offset + len(batch_plan)
+            batch_prompt = (
+                f"{prompt}\n\nGenerate only batch {batch_index} of {batch_count}, "
+                f"covering global segments {first_segment} through {last_segment}. "
+                "Number this batch locally starting at 1; the pipeline will renumber it. "
+                "Continue the same narrative rather than restarting it."
+            )
+            if video_prompts:
+                batch_prompt += (
+                    " The previous batch ended with: "
+                    f"{video_prompts[-1]['prompt']}"
+                )
+
+            batch_result = enhancer.enhance(
+                build_prompt_enhancement_instructions(batch_config), batch_prompt
+            )
+            validate_prompt_enhancement(batch_result, batch_config)
+            reasonings.append(batch_result["segmentation_logic"]["reasoning"])
+
+            for local_index, (keyframe_prompt, video_prompt) in enumerate(
+                zip(
+                    batch_result["keyframe_prompts"],
+                    batch_result["video_prompts"],
+                    strict=True,
+                ),
+                start=1,
+            ):
+                segment = offset + local_index
+                keyframe_prompt = {**keyframe_prompt, "segment": segment}
+                video_prompt = {
+                    **video_prompt,
+                    "segment": segment,
+                    "first_frame": (
+                        "provided_start_image.png"
+                        if segment == 1
+                        else f"segment_{segment - 1:02d}.png"
+                    ),
+                    "last_frame": f"segment_{segment:02d}.png",
+                }
+                keyframe_prompts.append(keyframe_prompt)
+                video_prompts.append(video_prompt)
+
+        result = {
+            "segmentation_logic": {
+                "total_duration_seconds": int(config["duration_seconds"]),
+                "number_of_segments": len(plan),
+                "reasoning": " ".join(reasonings),
+            },
+            "keyframe_prompts": keyframe_prompts,
+            "video_prompts": video_prompts,
+        }
+
     validate_prompt_enhancement(result, config)
     tradeoff = get_duration_tradeoff(config)
     if tradeoff:
@@ -494,14 +587,7 @@ def prepare_keyframes(
             frame_ref = prompt_item.get(field)
             if not frame_ref:
                 continue
-            if frame_ref == "provided_start_image.png":
-                frame_ref = "segment_00.png"
-            if os.path.isabs(frame_ref):
-                frame_path = os.path.abspath(frame_ref)
-            else:
-                frame_path = os.path.abspath(os.path.join(frames_dir, frame_ref))
-                if os.path.commonpath((frames_dir, frame_path)) != frames_dir:
-                    raise ValueError(f"Invalid {field} path: {frame_ref}")
+            frame_path = resolve_frame_reference(frame_ref, frames_dir)
             if not os.path.exists(frame_path):
                 raise FileNotFoundError(f"{field} not found: {frame_path}")
             prompt_item[field] = frame_path
@@ -865,7 +951,9 @@ def generate_video_segments_single_keyframe(
         segment_duration = prompt_item.get(
             "duration_seconds", config.get("segment_duration_seconds", 5.0)
         )
-        last_frame_path = prompt_item.get("last_frame")
+        last_frame_path = resolve_frame_reference(
+            prompt_item.get("last_frame"), frames_dir_abs
+        )
 
         # Veo first/last-frame generation always starts from the first frame.
         if backend == 'veo3':
@@ -881,17 +969,7 @@ def generate_video_segments_single_keyframe(
             # Default to first frame
             keyframe_path = prompt_item.get('first_frame', prompt_item.get('last_frame'))
 
-        # Fix keyframe path to use absolute path
-        if keyframe_path:
-            if keyframe_path == 'provided_start_image.png':
-                # This should be segment_00.png
-                keyframe_path = os.path.join(frames_dir_abs, 'segment_00.png')
-            elif keyframe_path.startswith('segment_') and keyframe_path.endswith('.png'):
-                # Convert relative segment reference to absolute path
-                keyframe_path = os.path.join(frames_dir_abs, keyframe_path)
-            else:
-                # For any other reference, try to resolve it
-                keyframe_path = os.path.join(frames_dir_abs, keyframe_path)
+        keyframe_path = resolve_frame_reference(keyframe_path, frames_dir_abs)
 
         if not keyframe_path:
             logging.error(f"No keyframe found for segment {seg}")
@@ -926,11 +1004,19 @@ def generate_video_segments_single_keyframe(
             fallback_generator = factory.get_fallback_generator(backend, config)
             if fallback_generator:
                 logging.info(f"Trying fallback generator for segment {seg}")
+                fallback_backend = str(
+                    config.get("remote_api_settings", {}).get("fallback_backend", "")
+                ).lower()
+                fallback_duration = (
+                    config.get("segment_duration_seconds", 5.0)
+                    if backend == "veo3" and fallback_backend != "veo3"
+                    else segment_duration
+                )
                 fallback_generator.generate_video(
                     prompt=prompt_text,
                     input_image_path=keyframe_path,
                     output_path=video_file,
-                    duration=segment_duration,
+                    duration=fallback_duration,
                     last_frame_path=last_frame_path,
                 )
                 video_paths.append(video_file)

--- a/pipeline_config.yaml.sample
+++ b/pipeline_config.yaml.sample
@@ -20,8 +20,8 @@ prompt: >
 # If set to "auto", the system will automatically select the best available backend
 default_backend: veo3
 
-# Generation mode settings (for local Wan2.1 backend)
-generation_mode: "chaining"  # Options: "keyframe" or "chaining"
+# Generation mode settings
+generation_mode: "keyframe"  # Required for Veo first/last-frame generation
 
 # ============================================================================
 # LOCAL BACKEND CONFIGURATION (Wan2.1)
@@ -79,7 +79,7 @@ google_veo:
   project_id: "YOUR_GCP_PROJECT_ID"      # Required for Veo 3
   credentials_path: "credentials/credentials.json"  # Path to service account credentials
   region: "us-central1"
-  veo_model: "veo-3.0-generate-preview"  # Veo 3
+  veo_model: "veo-3.1-generate-001"      # Or veo-3.1-fast-generate-001
 #  output_bucket: "your-output-bucket"    # Optional: GCS bucket for outputs
 
 # Remote API configuration - Minimax
@@ -119,7 +119,7 @@ image_generation_model: "gemini-2.5-flash-image-preview"
 # - For models supporting I2I (Gemini, Stability AI): reference images will be automatically loaded
 # - For models not supporting I2I (OpenAI): falls back to T2I generation
 # - If reference_images_dir is empty and auto_generate_initial is true, initial reference is generated
-# - Single keyframe mode is required for Veo3 (no FLF support)
+# - This remote-keyframe path sends both first and last frames to Veo 3.1
 # Reference images directory - place all reference images here
 # Images will be automatically loaded and used for character/setting consistency
 reference_images_dir: "input"  # Directory containing reference images
@@ -134,8 +134,8 @@ image_size: "1024x1024"  # 1:1 aspect ratio - compatible with veo3 input require
 # Auto-generate initial reference image if not provided
 auto_generate_initial: true  # Generate initial image if reference_images_dir is empty
 
-# Single keyframe mode for Veo3 (no FLF support)
-single_keyframe_mode: true   # Generate one keyframe per segment for I2V
+# Remote keyframe mode for Veo3
+single_keyframe_mode: true   # Send each segment's first and last keyframes to Veo
 
 # Position of keyframe for I2V generation: first/middle/last
 keyframe_position: "first"  # Position of keyframe: first/middle/last
@@ -169,6 +169,7 @@ video_aspect_ratio: "16:9"  # Default to widescreen landscape
 
 # Video generation parameters (applies to all backends)
 segment_duration_seconds: 5.0 # Desired duration for each video segment in seconds
+# duration_seconds: 15        # Optional requested final runtime; Veo plans 4/6/8s clips and trims only if needed
 frame_num: 81         # Number of frames (for ~5 seconds at 16fps)
 sample_steps: 40      # Sampling steps
 sample_shift: 5.0     # Sampling shift factor

--- a/pipeline_config.yaml.sample
+++ b/pipeline_config.yaml.sample
@@ -169,7 +169,7 @@ video_aspect_ratio: "16:9"  # Default to widescreen landscape
 
 # Video generation parameters (applies to all backends)
 segment_duration_seconds: 5.0 # Desired duration for each video segment in seconds
-# duration_seconds: 15        # Optional requested final runtime; Veo plans 4/6/8s clips and trims only if needed
+# duration_seconds: 15        # Optional requested final runtime (max 14440s); Veo plans 4/6/8s clips and trims only if needed
 frame_num: 81         # Number of frames (for ~5 seconds at 16fps)
 sample_steps: 40      # Sampling steps
 sample_shift: 5.0     # Sampling shift factor

--- a/plans/workspace-recovery-and-roadmap.md
+++ b/plans/workspace-recovery-and-roadmap.md
@@ -1,6 +1,6 @@
 # TTV Pipeline Recovery and Product Roadmap
 
-Status: Phase 1 complete; Phase 2 pending
+Status: Phase 2 complete; Phase 3 pending
 Last updated: 2026-07-18
 Workspace: `/Users/magos/dev/kumanday/Parlina/ttv-pipeline`
 
@@ -207,7 +207,7 @@ Phase 1 validation:
 
 ## Phase 2 - Veo 3.1 and requested duration
 
-Status: pending
+Status: complete
 Priority: highest product priority
 
 Goal: deliver a correct direct-Vertex Veo 3.1 vertical slice with first/last
@@ -215,19 +215,19 @@ frames and requested final duration.
 
 Required work:
 
-- Default to `veo-3.1-generate-001`, while allowing the fast GA model through
+- [x] Default to `veo-3.1-generate-001`, while allowing the fast GA model through
   configuration.
-- Forward the configured Veo model through the factory.
-- Represent Veo clip durations as allowed values `[4, 6, 8]`, not a scalar max.
-- Send `duration_seconds` to the Google SDK.
-- Pass the existing ending keyframe via `GenerateVideosConfig.last_frame`.
-- Add optional CLI `--duration-seconds` and API `duration_seconds`.
-- Omitted duration preserves AI-inferred behavior.
-- Provided duration constrains decomposition and final runtime.
-- Plan provider-compatible segment durations; trim only when an exact sum is
+- [x] Forward the configured Veo model through the factory.
+- [x] Represent Veo clip durations as allowed values `[4, 6, 8]`, not a scalar max.
+- [x] Send `duration_seconds` to the Google SDK.
+- [x] Pass the existing ending keyframe via `GenerateVideosConfig.last_frame`.
+- [x] Add optional CLI `--duration-seconds` and API `duration_seconds`.
+- [x] Omitted duration preserves AI-inferred behavior.
+- [x] Provided duration constrains decomposition and final runtime.
+- [x] Plan provider-compatible segment durations; trim only when an exact sum is
   impossible, and surface the first/last-frame tradeoff for a trimmed final clip.
-- Validate LLM output against the requested segment plan.
-- Add mocked tests asserting model, duration, first frame, and last frame in the
+- [x] Validate LLM output against the requested segment plan.
+- [x] Add mocked tests asserting model, duration, first frame, and last frame in the
   actual Google request.
 
 Sizing:
@@ -235,6 +235,41 @@ Sizing:
 - Direct Veo 3.1 plus one-provider duration support is a bounded Codex task.
 - A generalized multi-provider duration planner should become a separate spec if
   more than the initial providers require materially different behavior.
+
+Phase 2 result:
+
+- Direct Vertex generation now defaults to `veo-3.1-generate-001`; setting
+  `google_veo.veo_model: veo-3.1-fast-generate-001` selects the fast GA model.
+- Veo capabilities and validation use the provider's discrete 4, 6, and 8 second
+  clip lengths. The Google SDK request receives the selected model, per-segment
+  `duration_seconds`, the first image, and `GenerateVideosConfig.last_frame`.
+- CLI `--duration-seconds` and API `duration_seconds` flow through the effective
+  job configuration. Without a request, the LLM still infers runtime and segment
+  count while choosing provider-compatible clip lengths.
+- Requested runtimes are decomposed into the fewest Veo-compatible clips. Odd or
+  sub-four-second requests use the smallest covering plan and trim only the final
+  output. The API response and worker/CLI logs warn that trimming removes the
+  final generated ending keyframe.
+- Both prompt-enhancement paths now share one instruction and validation flow.
+  LLM segment numbers, counts, total runtime, and per-segment durations must match
+  the requested plan before keyframe or video generation starts.
+- Exact-sum concatenation remains stream-copy. Only the impossible-sum trim path
+  re-encodes, because stream-copy trimming was measurably inexact at packet
+  boundaries.
+
+Phase 2 validation:
+
+- Focused Python 3.14 suite: 122 passed.
+- Mocked `google-genai` request asserts the default model, duration, first-frame
+  GCS image, and last-frame GCS image; a factory test covers the fast model.
+- Mocked API-to-worker smoke test proves requested duration survives redacted job
+  storage and secret restoration, and the API surfaces the trim warning.
+- Real ffmpeg check concatenated 4- and 6-second clips, trimmed the covering plan,
+  and produced an ffprobe duration of exactly `9.000000` seconds.
+- Python compilation, YAML parsing, CLI help, and `git diff --check` pass.
+- A broader legacy `tests/test_main.py` probe still reproduces the Phase 1
+  baseline failures for obsolete routes/fixtures and live readiness dependencies;
+  no Phase 2 code path is implicated.
 
 ## Phase 3 - Correct fal.ai support
 

--- a/tests/mocks/mock_generators.py
+++ b/tests/mocks/mock_generators.py
@@ -216,9 +216,9 @@ class MockVeo3Generator(MockVideoGenerator):
     def get_capabilities(self) -> Dict[str, Any]:
         capabilities = super().get_capabilities()
         capabilities.update({
-            "max_duration": 5.0,
+            "supported_durations": [4, 6, 8],
             "models": {
-                "veo-3.0-generate-preview": True
+                "veo-3.1-generate-001": True
             },
             "features": {
                 "motion_control": True,

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -12,7 +12,7 @@ from workers.video_worker import process_video_job
 def test_mocked_api_job_reaches_worker_with_effective_config():
     pipeline_config = {
         "prompt": "default prompt",
-        "default_backend": "fal",
+        "default_backend": "veo3",
         "image_generation_model": "openai/gpt-image-1",
         "openai_api_key": "test-secret",
         "minimax": {"api_key": "nested-secret", "model": "I2V-01-Director"},
@@ -27,16 +27,21 @@ def test_mocked_api_job_reaches_worker_with_effective_config():
     app.state.job_queue = queue
     client = TestClient(app)
 
-    create_response = client.post("/v1/jobs", json={"prompt": "HTTP prompt"})
+    create_response = client.post(
+        "/v1/jobs",
+        json={"prompt": "HTTP prompt", "duration_seconds": 9},
+    )
     assert create_response.status_code == 202
+    assert "ending keyframe will not appear" in create_response.json()["warnings"][0]
     job_id = create_response.json()["id"]
     stored_config = queue.get_job(job_id).config.copy()
     assert stored_config == {
-        "default_backend": "fal",
+        "default_backend": "veo3",
         "image_generation_model": "openai/gpt-image-1",
         "openai_api_key": "[REDACTED]",
         "minimax": {"api_key": "[REDACTED]", "model": "I2V-01-Director"},
         "prompt": "HTTP prompt",
+        "duration_seconds": 9,
         "gcs_bucket": "test-bucket",
         "gcs_prefix": "ttv-api",
         "credentials_path": "[REDACTED]",
@@ -55,6 +60,7 @@ def test_mocked_api_job_reaches_worker_with_effective_config():
     assert execute.call_args.kwargs["config"] == {
         **pipeline_config,
         "prompt": "HTTP prompt",
+        "duration_seconds": 9,
         "gcs_bucket": "test-bucket",
         "gcs_prefix": "ttv-api",
         "credentials_path": "test-credentials.json",

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -13,6 +13,8 @@ def test_mocked_api_job_reaches_worker_with_effective_config():
     pipeline_config = {
         "prompt": "default prompt",
         "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
         "image_generation_model": "openai/gpt-image-1",
         "openai_api_key": "test-secret",
         "minimax": {"api_key": "nested-secret", "model": "I2V-01-Director"},
@@ -27,16 +29,20 @@ def test_mocked_api_job_reaches_worker_with_effective_config():
     app.state.job_queue = queue
     client = TestClient(app)
 
-    create_response = client.post(
-        "/v1/jobs",
-        json={"prompt": "HTTP prompt", "duration_seconds": 9},
-    )
+    with patch.object(queue, "enqueue_job", wraps=queue.enqueue_job) as enqueue_job:
+        create_response = client.post(
+            "/v1/jobs",
+            json={"prompt": "HTTP prompt", "duration_seconds": 9},
+        )
     assert create_response.status_code == 202
+    assert enqueue_job.call_args.kwargs["job_timeout"] == 4800
     assert "ending keyframe will not appear" in create_response.json()["warnings"][0]
     job_id = create_response.json()["id"]
     stored_config = queue.get_job(job_id).config.copy()
     assert stored_config == {
         "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
         "image_generation_model": "openai/gpt-image-1",
         "openai_api_key": "[REDACTED]",
         "minimax": {"api_key": "[REDACTED]", "model": "I2V-01-Director"},

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -16,6 +16,7 @@ from pipeline import (
     enhance_prompt_data,
     generate_video_segments_single_keyframe,
     get_duration_tradeoff,
+    get_requested_job_timeout,
     get_requested_segment_plan,
     get_trim_duration_seconds,
     main,
@@ -71,7 +72,12 @@ def test_requested_duration_plan_and_llm_validation():
     assert "duration_seconds values [4, 6]" in build_prompt_enhancement_instructions(config)
     assert "ending keyframe will not appear" in get_duration_tradeoff(config)
     assert get_trim_duration_seconds(config) == 9
-    assert get_trim_duration_seconds({"default_backend": "veo3", "duration_seconds": 10}) is None
+    assert get_trim_duration_seconds({
+        "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "duration_seconds": 10,
+    }) is None
 
     result["video_prompts"][1]["last_frame"] = None
     with pytest.raises(ValueError, match="first_frame and last_frame"):
@@ -187,7 +193,12 @@ def test_requested_duration_disables_incompatible_fallback(tmp_path):
          patch("generators.factory.get_fallback_generator") as get_fallback:
         with pytest.raises(VideoGenerationError, match="Veo failed"):
             generate_video_segments_single_keyframe(
-                {"default_backend": "veo3", "duration_seconds": 6},
+                {
+                    "default_backend": "veo3",
+                    "generation_mode": "keyframe",
+                    "single_keyframe_mode": True,
+                    "duration_seconds": 6,
+                },
                 [{
                     "segment": 1,
                     "prompt": "move",
@@ -319,7 +330,12 @@ def test_long_requested_duration_batches_prompt_enhancement():
         ]
         result = enhance_prompt_data(
             "A long journey",
-            {"default_backend": "veo3", "duration_seconds": 168},
+            {
+                "default_backend": "veo3",
+                "generation_mode": "keyframe",
+                "single_keyframe_mode": True,
+                "duration_seconds": 168,
+            },
         )
 
     assert prompt_enhancer.return_value.enhance.call_count == 2
@@ -332,18 +348,33 @@ def test_long_requested_duration_batches_prompt_enhancement():
 def test_chaining_mode_validates_its_actual_backend():
     config = {
         "generation_mode": "chaining",
-        "default_backend": "wan2.1",
-        "default_video_generation_backend": "veo3",
+        "default_backend": "veo3",
         "duration_seconds": 6,
     }
-    with pytest.raises(ValueError, match="supported only for the veo3 backend"):
+    with pytest.raises(ValueError, match="requires generation_mode=keyframe"):
         get_requested_segment_plan(config)
+
+
+def test_requested_duration_scales_queue_timeout():
+    config = {
+        "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "duration_seconds": MAX_REQUESTED_DURATION_SECONDS,
+        "remote_api_settings": {"timeout": 600},
+    }
+    assert get_requested_job_timeout(config) == 3600 + 1805 * 600
 
 
 def test_cli_rejects_unsupported_duration_before_generation():
     with patch(
         "pipeline.load_config",
-        return_value={"prompt": "move", "default_backend": "wan2.1"},
+        return_value={
+            "prompt": "move",
+            "default_backend": "wan2.1",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+        },
     ), patch("pipeline.enhance_prompt") as enhance_prompt:
         with pytest.raises(ValueError, match="supported only for the veo3 backend"):
             run_pipeline("config.yaml", duration_seconds=6)

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -14,6 +14,7 @@ from pipeline import (
     VideoPrompt,
     build_prompt_enhancement_instructions,
     enhance_prompt_data,
+    generate_video_chaining_mode,
     generate_video_segments_single_keyframe,
     get_duration_tradeoff,
     get_requested_job_timeout,
@@ -180,6 +181,44 @@ def test_inferred_veo_fallback_uses_configured_duration(tmp_path):
             str(tmp_path),
         )
 
+    assert fallback.generate_video.call_args.kwargs["duration"] == 5
+
+
+def test_chaining_veo_fallback_uses_configured_duration(tmp_path):
+    frame = tmp_path / "frame.png"
+    frame.touch()
+    primary = Mock()
+    primary.get_backend_name.return_value = "veo3"
+    primary.validate_inputs.return_value = []
+    primary.generate_video.side_effect = VideoGenerationError("Veo failed")
+    fallback = Mock()
+    fallback.get_backend_name.return_value = "minimax"
+    fallback.validate_inputs.return_value = []
+
+    def generate_fallback(**kwargs):
+        with open(kwargs["output_path"], "wb") as file:
+            file.write(b"video")
+        return kwargs["output_path"]
+
+    fallback.generate_video.side_effect = generate_fallback
+    config = {
+        "default_backend": "veo3",
+        "initial_image": str(frame),
+        "segment_duration_seconds": 5,
+        "remote_api_settings": {"fallback_backend": "minimax"},
+    }
+
+    with patch("pipeline.create_video_generator", return_value=primary), \
+         patch("pipeline.get_fallback_generator", return_value=fallback):
+        generate_video_chaining_mode(
+            config,
+            [{"segment": 1, "prompt": "move", "duration_seconds": 8}],
+            str(tmp_path),
+            segment_duration=5,
+        )
+
+    assert primary.validate_inputs.call_args.kwargs["duration"] == 8
+    assert fallback.validate_inputs.call_args.kwargs["duration"] == 5
     assert fallback.generate_video.call_args.kwargs["duration"] == 5
 
 

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -17,6 +17,7 @@ from pipeline import (
     generate_video_chaining_mode,
     generate_video_segments_single_keyframe,
     get_duration_tradeoff,
+    get_provider_compatible_duration,
     get_requested_job_timeout,
     get_requested_segment_plan,
     get_trim_duration_seconds,
@@ -121,8 +122,19 @@ def test_omitted_duration_keeps_veo_planning_ai_inferred():
     }
 
     validate_prompt_enhancement(result, config)
-    assert "Infer the final runtime" in build_prompt_enhancement_instructions(config)
+    instructions = build_prompt_enhancement_instructions(config)
+    assert "Infer the final runtime" in instructions
+    assert '"total_duration_seconds": 8' in instructions
+    assert instructions.count('"duration_seconds": 4') >= 2
+    assert '"duration_seconds": 5' not in instructions
     assert get_trim_duration_seconds(config) is None
+
+
+def test_fallback_to_veo_uses_supported_duration():
+    config = {"segment_duration_seconds": 5}
+
+    assert get_provider_compatible_duration(config, "minimax", "veo3", 5) == 6
+    assert get_provider_compatible_duration(config, "fal", "veo3", 9) == 8
 
 
 def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -11,9 +11,12 @@ from generators.factory import create_video_generator
 from generators.remote.veo3_generator import Veo3Generator
 from pipeline import (
     MAX_REQUESTED_DURATION_SECONDS,
+    VideoPrompt,
     build_prompt_enhancement_instructions,
+    enhance_prompt_data,
     generate_video_segments_single_keyframe,
     get_duration_tradeoff,
+    get_requested_segment_plan,
     get_trim_duration_seconds,
     main,
     plan_veo_segment_durations,
@@ -32,6 +35,8 @@ def test_requested_duration_plan_and_llm_validation():
     config = {
         "default_backend": "wan2.1",
         "default_video_generation_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
         "duration_seconds": 9,
     }
     result = {
@@ -115,7 +120,9 @@ def test_omitted_duration_keeps_veo_planning_ai_inferred():
 
 def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
     first_frame = tmp_path / "first.png"
-    last_frame = tmp_path / "last.png"
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    last_frame = frames_dir / "last.png"
     first_frame.touch()
     last_frame.touch()
     generator = Mock()
@@ -130,7 +137,7 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
                 "segment": 1,
                 "prompt": "move",
                 "first_frame": str(first_frame),
-                "last_frame": str(last_frame),
+                "last_frame": "last.png",
                 "duration_seconds": 6,
             }],
             str(tmp_path),
@@ -139,6 +146,35 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
     assert generator.generate_video.call_args.kwargs["duration"] == 6
     assert generator.generate_video.call_args.kwargs["input_image_path"] == str(first_frame)
     assert generator.generate_video.call_args.kwargs["last_frame_path"] == str(last_frame)
+
+
+def test_inferred_veo_fallback_uses_configured_duration(tmp_path):
+    frame = tmp_path / "frame.png"
+    frame.touch()
+    generator = Mock()
+    generator.generate_video.side_effect = VideoGenerationError("Veo failed")
+    fallback = Mock()
+    config = {
+        "default_backend": "veo3",
+        "segment_duration_seconds": 5,
+        "remote_api_settings": {"fallback_backend": "minimax"},
+    }
+
+    with patch("generators.factory.create_video_generator", return_value=generator), \
+         patch("generators.factory.get_fallback_generator", return_value=fallback):
+        generate_video_segments_single_keyframe(
+            config,
+            [{
+                "segment": 1,
+                "prompt": "move",
+                "first_frame": str(frame),
+                "last_frame": str(frame),
+                "duration_seconds": 8,
+            }],
+            str(tmp_path),
+        )
+
+    assert fallback.generate_video.call_args.kwargs["duration"] == 5
 
 
 def test_requested_duration_disables_incompatible_fallback(tmp_path):
@@ -244,6 +280,64 @@ def test_duration_limit_and_api_validation():
         JobCreateRequest(prompt="move", duration_seconds=True)
     with pytest.raises(ValidationError):
         JobCreateRequest(prompt="move", duration_seconds=14_441)
+    with pytest.raises(ValidationError):
+        VideoPrompt(segment=1, prompt="move")
+
+
+def test_long_requested_duration_batches_prompt_enhancement():
+    def batch_result(durations):
+        return {
+            "segmentation_logic": {
+                "total_duration_seconds": sum(durations),
+                "number_of_segments": len(durations),
+                "reasoning": "continue the narrative",
+            },
+            "keyframe_prompts": [
+                {"segment": index, "prompt": f"frame {index}"}
+                for index in range(1, len(durations) + 1)
+            ],
+            "video_prompts": [
+                {
+                    "segment": index,
+                    "prompt": f"video {index}",
+                    "first_frame": (
+                        "provided_start_image.png"
+                        if index == 1
+                        else f"segment_{index - 1:02d}.png"
+                    ),
+                    "last_frame": f"segment_{index:02d}.png",
+                    "duration_seconds": duration,
+                }
+                for index, duration in enumerate(durations, start=1)
+            ],
+        }
+
+    with patch("pipeline.PromptEnhancer") as prompt_enhancer:
+        prompt_enhancer.return_value.enhance.side_effect = [
+            batch_result([8] * 20),
+            batch_result([8]),
+        ]
+        result = enhance_prompt_data(
+            "A long journey",
+            {"default_backend": "veo3", "duration_seconds": 168},
+        )
+
+    assert prompt_enhancer.return_value.enhance.call_count == 2
+    assert result["segmentation_logic"]["number_of_segments"] == 21
+    assert result["video_prompts"][20]["segment"] == 21
+    assert result["video_prompts"][20]["first_frame"] == "segment_20.png"
+    assert result["video_prompts"][20]["last_frame"] == "segment_21.png"
+
+
+def test_chaining_mode_validates_its_actual_backend():
+    config = {
+        "generation_mode": "chaining",
+        "default_backend": "wan2.1",
+        "default_video_generation_backend": "veo3",
+        "duration_seconds": 6,
+    }
+    with pytest.raises(ValueError, match="supported only for the veo3 backend"):
+        get_requested_segment_plan(config)
 
 
 def test_cli_rejects_unsupported_duration_before_generation():

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -10,15 +10,18 @@ from api.models import JobCreateRequest
 from generators.factory import create_video_generator
 from generators.remote.veo3_generator import Veo3Generator
 from pipeline import (
+    MAX_REQUESTED_DURATION_SECONDS,
     build_prompt_enhancement_instructions,
     generate_video_segments_single_keyframe,
     get_duration_tradeoff,
     get_trim_duration_seconds,
     main,
     plan_veo_segment_durations,
+    run_pipeline,
     stitch_video_segments,
     validate_prompt_enhancement,
 )
+from video_generator_interface import VideoGenerationError
 
 
 def test_requested_duration_plan_and_llm_validation():
@@ -26,7 +29,11 @@ def test_requested_duration_plan_and_llm_validation():
     assert plan_veo_segment_durations(10) == [4, 6]
     assert plan_veo_segment_durations(17) == [8, 4, 6]
 
-    config = {"default_backend": "veo3", "duration_seconds": 9}
+    config = {
+        "default_backend": "wan2.1",
+        "default_video_generation_backend": "veo3",
+        "duration_seconds": 9,
+    }
     result = {
         "segmentation_logic": {
             "total_duration_seconds": 9,
@@ -38,8 +45,20 @@ def test_requested_duration_plan_and_llm_validation():
             {"segment": 2, "prompt": "second"},
         ],
         "video_prompts": [
-            {"segment": 1, "prompt": "first", "duration_seconds": 4},
-            {"segment": 2, "prompt": "second", "duration_seconds": 6},
+            {
+                "segment": 1,
+                "prompt": "first",
+                "first_frame": "provided_start_image.png",
+                "last_frame": "segment_01.png",
+                "duration_seconds": 4,
+            },
+            {
+                "segment": 2,
+                "prompt": "second",
+                "first_frame": "segment_01.png",
+                "last_frame": "segment_02.png",
+                "duration_seconds": 6,
+            },
         ],
     }
 
@@ -48,6 +67,11 @@ def test_requested_duration_plan_and_llm_validation():
     assert "ending keyframe will not appear" in get_duration_tradeoff(config)
     assert get_trim_duration_seconds(config) == 9
     assert get_trim_duration_seconds({"default_backend": "veo3", "duration_seconds": 10}) is None
+
+    result["video_prompts"][1]["last_frame"] = None
+    with pytest.raises(ValueError, match="first_frame and last_frame"):
+        validate_prompt_enhancement(result, config)
+    result["video_prompts"][1]["last_frame"] = "segment_02.png"
 
     result["video_prompts"][1]["duration_seconds"] = 8
     with pytest.raises(ValueError, match="requested segment plan"):
@@ -67,8 +91,20 @@ def test_omitted_duration_keeps_veo_planning_ai_inferred():
             {"segment": 2, "prompt": "second"},
         ],
         "video_prompts": [
-            {"segment": 1, "prompt": "first", "duration_seconds": 6},
-            {"segment": 2, "prompt": "second", "duration_seconds": 8},
+            {
+                "segment": 1,
+                "prompt": "first",
+                "first_frame": "provided_start_image.png",
+                "last_frame": "segment_01.png",
+                "duration_seconds": 6,
+            },
+            {
+                "segment": 2,
+                "prompt": "second",
+                "first_frame": "segment_01.png",
+                "last_frame": "segment_02.png",
+                "duration_seconds": 8,
+            },
         ],
     }
 
@@ -86,7 +122,10 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
 
     with patch("generators.factory.create_video_generator", return_value=generator):
         generate_video_segments_single_keyframe(
-            {"default_backend": "veo3"},
+            {
+                "default_backend": "veo3",
+                "i2i_mode": {"keyframe_position": "last"},
+            },
             [{
                 "segment": 1,
                 "prompt": "move",
@@ -100,6 +139,30 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
     assert generator.generate_video.call_args.kwargs["duration"] == 6
     assert generator.generate_video.call_args.kwargs["input_image_path"] == str(first_frame)
     assert generator.generate_video.call_args.kwargs["last_frame_path"] == str(last_frame)
+
+
+def test_requested_duration_disables_incompatible_fallback(tmp_path):
+    frame = tmp_path / "frame.png"
+    frame.touch()
+    generator = Mock()
+    generator.generate_video.side_effect = VideoGenerationError("Veo failed")
+
+    with patch("generators.factory.create_video_generator", return_value=generator), \
+         patch("generators.factory.get_fallback_generator") as get_fallback:
+        with pytest.raises(VideoGenerationError, match="Veo failed"):
+            generate_video_segments_single_keyframe(
+                {"default_backend": "veo3", "duration_seconds": 6},
+                [{
+                    "segment": 1,
+                    "prompt": "move",
+                    "first_frame": str(frame),
+                    "last_frame": str(frame),
+                    "duration_seconds": 6,
+                }],
+                str(tmp_path),
+            )
+
+    get_fallback.assert_not_called()
 
 
 def test_veo_factory_forwards_fast_model():
@@ -172,6 +235,23 @@ def test_trim_and_cli_duration_interfaces(tmp_path):
     run_pipeline.assert_called_once_with("config.yaml", None, 15)
 
 
-def test_api_rejects_boolean_duration():
+def test_duration_limit_and_api_validation():
+    assert sum(plan_veo_segment_durations(MAX_REQUESTED_DURATION_SECONDS)) == 14_440
+    with pytest.raises(ValueError, match="at most 14440"):
+        plan_veo_segment_durations(14_441)
+
     with pytest.raises(ValidationError):
         JobCreateRequest(prompt="move", duration_seconds=True)
+    with pytest.raises(ValidationError):
+        JobCreateRequest(prompt="move", duration_seconds=14_441)
+
+
+def test_cli_rejects_unsupported_duration_before_generation():
+    with patch(
+        "pipeline.load_config",
+        return_value={"prompt": "move", "default_backend": "wan2.1"},
+    ), patch("pipeline.enhance_prompt") as enhance_prompt:
+        with pytest.raises(ValueError, match="supported only for the veo3 backend"):
+            run_pipeline("config.yaml", duration_seconds=6)
+
+    enhance_prompt.assert_not_called()

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -1,0 +1,177 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+
+from api.models import JobCreateRequest
+from generators.factory import create_video_generator
+from generators.remote.veo3_generator import Veo3Generator
+from pipeline import (
+    build_prompt_enhancement_instructions,
+    generate_video_segments_single_keyframe,
+    get_duration_tradeoff,
+    get_trim_duration_seconds,
+    main,
+    plan_veo_segment_durations,
+    stitch_video_segments,
+    validate_prompt_enhancement,
+)
+
+
+def test_requested_duration_plan_and_llm_validation():
+    assert plan_veo_segment_durations(4) == [4]
+    assert plan_veo_segment_durations(10) == [4, 6]
+    assert plan_veo_segment_durations(17) == [8, 4, 6]
+
+    config = {"default_backend": "veo3", "duration_seconds": 9}
+    result = {
+        "segmentation_logic": {
+            "total_duration_seconds": 9,
+            "number_of_segments": 2,
+            "reasoning": "requested runtime",
+        },
+        "keyframe_prompts": [
+            {"segment": 1, "prompt": "first"},
+            {"segment": 2, "prompt": "second"},
+        ],
+        "video_prompts": [
+            {"segment": 1, "prompt": "first", "duration_seconds": 4},
+            {"segment": 2, "prompt": "second", "duration_seconds": 6},
+        ],
+    }
+
+    validate_prompt_enhancement(result, config)
+    assert "duration_seconds values [4, 6]" in build_prompt_enhancement_instructions(config)
+    assert "ending keyframe will not appear" in get_duration_tradeoff(config)
+    assert get_trim_duration_seconds(config) == 9
+    assert get_trim_duration_seconds({"default_backend": "veo3", "duration_seconds": 10}) is None
+
+    result["video_prompts"][1]["duration_seconds"] = 8
+    with pytest.raises(ValueError, match="requested segment plan"):
+        validate_prompt_enhancement(result, config)
+
+
+def test_omitted_duration_keeps_veo_planning_ai_inferred():
+    config = {"default_backend": "veo3"}
+    result = {
+        "segmentation_logic": {
+            "total_duration_seconds": 14,
+            "number_of_segments": 2,
+            "reasoning": "inferred runtime",
+        },
+        "keyframe_prompts": [
+            {"segment": 1, "prompt": "first"},
+            {"segment": 2, "prompt": "second"},
+        ],
+        "video_prompts": [
+            {"segment": 1, "prompt": "first", "duration_seconds": 6},
+            {"segment": 2, "prompt": "second", "duration_seconds": 8},
+        ],
+    }
+
+    validate_prompt_enhancement(result, config)
+    assert "Infer the final runtime" in build_prompt_enhancement_instructions(config)
+    assert get_trim_duration_seconds(config) is None
+
+
+def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
+    first_frame = tmp_path / "first.png"
+    last_frame = tmp_path / "last.png"
+    first_frame.touch()
+    last_frame.touch()
+    generator = Mock()
+
+    with patch("generators.factory.create_video_generator", return_value=generator):
+        generate_video_segments_single_keyframe(
+            {"default_backend": "veo3"},
+            [{
+                "segment": 1,
+                "prompt": "move",
+                "first_frame": str(first_frame),
+                "last_frame": str(last_frame),
+                "duration_seconds": 6,
+            }],
+            str(tmp_path),
+        )
+
+    assert generator.generate_video.call_args.kwargs["duration"] == 6
+    assert generator.generate_video.call_args.kwargs["input_image_path"] == str(first_frame)
+    assert generator.generate_video.call_args.kwargs["last_frame_path"] == str(last_frame)
+
+
+def test_veo_factory_forwards_fast_model():
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = create_video_generator(
+            "veo3",
+            {
+                "google_veo": {
+                    "project_id": "test-project",
+                    "veo_model": "veo-3.1-fast-generate-001",
+                }
+            },
+        )
+
+    assert generator.model_name == "veo-3.1-fast-generate-001"
+
+
+def test_veo_request_contains_model_duration_and_both_frames(tmp_path):
+    first_frame = tmp_path / "first.png"
+    last_frame = tmp_path / "last.png"
+    Image.new("RGB", (128, 72)).save(first_frame)
+    Image.new("RGB", (128, 72)).save(last_frame)
+    output_path = tmp_path / "video.mp4"
+
+    operation = SimpleNamespace(
+        done=True,
+        response=object(),
+        result=SimpleNamespace(
+            generated_videos=[SimpleNamespace(video=SimpleNamespace(uri="gs://outputs/video.mp4"))]
+        ),
+    )
+    generate_videos = Mock(return_value=operation)
+
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = Veo3Generator({"project_id": "test-project", "max_retries": 1})
+    generator.genai_client = SimpleNamespace(
+        models=SimpleNamespace(generate_videos=generate_videos),
+        operations=Mock(),
+    )
+    generator.storage_client = Mock()
+    generator._ensure_bucket_exists = Mock()
+    generator._upload_to_gcs = Mock(side_effect=["gs://inputs/first.png", "gs://inputs/last.png"])
+    generator._download_from_gcs = Mock(return_value=str(output_path))
+
+    generator.generate_video(
+        prompt="A smooth transition",
+        input_image_path=str(first_frame),
+        last_frame_path=str(last_frame),
+        output_path=str(output_path),
+        duration=6,
+    )
+
+    request = generate_videos.call_args.kwargs
+    assert request["model"] == "veo-3.1-generate-001"
+    assert request["image"].gcs_uri == "gs://inputs/first.png"
+    assert request["config"].duration_seconds == 6
+    assert request["config"].last_frame.gcs_uri == "gs://inputs/last.png"
+
+
+def test_trim_and_cli_duration_interfaces(tmp_path):
+    with patch("pipeline.run_command") as run_command:
+        stitch_video_segments(["segment.mp4"], str(tmp_path / "final.mp4"), 9)
+    command = run_command.call_args.args[0]
+    assert command[command.index("-t") + 1] == "9"
+    assert command[command.index("-c:v") + 1] == "libx264"
+
+    with patch.object(sys, "argv", ["pipeline.py", "--config", "config.yaml", "--duration-seconds", "15"]), \
+         patch("pipeline.run_pipeline") as run_pipeline:
+        main()
+    run_pipeline.assert_called_once_with("config.yaml", None, 15)
+
+
+def test_api_rejects_boolean_duration():
+    with pytest.raises(ValidationError):
+        JobCreateRequest(prompt="move", duration_seconds=True)

--- a/workers/trio_video_worker.py
+++ b/workers/trio_video_worker.py
@@ -273,7 +273,11 @@ async def execute_pipeline_with_trio(
         # Stitch segments together
         final_video_path = os.path.join(job_output_dir, "final_video.mp4")
         stitched_path = await stitch_video_segments_trio(
-            video_paths, final_video_path, cancellation_token, nursery
+            video_paths,
+            final_video_path,
+            cancellation_token,
+            nursery,
+            final_config,
         )
         
         if not stitched_path or not os.path.exists(stitched_path):
@@ -336,15 +340,9 @@ async def enhance_prompt_trio(
         Enhancement result with keyframe and video prompts
     """
     def enhance_sync():
-        from pipeline import PromptEnhancer, PROMPT_ENHANCEMENT_INSTRUCTIONS
-        
-        enhancer = PromptEnhancer(
-            api_key=config.get('openai_api_key'),
-            base_url=config.get('openai_base_url', 'https://api.openai.com/v1'),
-            model=config.get('prompt_enhancement_model', 'gpt-4o-mini')
-        )
-        
-        return enhancer.enhance(PROMPT_ENHANCEMENT_INSTRUCTIONS, prompt)
+        from pipeline import enhance_prompt_data
+
+        return enhance_prompt_data(prompt, config)
     
     # Run enhancement in thread with cancellation check
     if await check_cancellation_async(cancellation_token, job_id=""):
@@ -485,7 +483,8 @@ async def stitch_video_segments_trio(
     video_paths: list,
     final_video_path: str,
     cancellation_token: TrioCancellationToken,
-    nursery: trio.Nursery
+    nursery: trio.Nursery,
+    config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Stitch video segments using Trio structured concurrency
@@ -504,8 +503,10 @@ async def stitch_video_segments_trio(
         raise InterruptedError("Job cancelled before video stitching")
     
     def stitch_sync():
-        from pipeline import stitch_video_segments
-        return stitch_video_segments(video_paths, final_video_path)
+        from pipeline import get_trim_duration_seconds, stitch_video_segments
+
+        trim_duration = get_trim_duration_seconds(config or {})
+        return stitch_video_segments(video_paths, final_video_path, trim_duration)
     
     # Run stitching in thread
     return await trio.to_thread.run_sync(stitch_sync)

--- a/workers/video_worker.py
+++ b/workers/video_worker.py
@@ -405,8 +405,9 @@ def execute_pipeline_with_config(
             
             # Import pipeline functions
             from pipeline import (
-                PromptEnhancer, stitch_video_segments,
-                PROMPT_ENHANCEMENT_INSTRUCTIONS,
+                enhance_prompt_data,
+                get_trim_duration_seconds,
+                stitch_video_segments,
             )
             final_config = config
             
@@ -422,15 +423,8 @@ def execute_pipeline_with_config(
             job_queue.update_job_status(job_id, JobStatus.PROGRESS, progress=20)
             job_queue.add_job_log(job_id, "Enhancing and segmenting prompt")
             
-            # Initialize prompt enhancer
-            enhancer = PromptEnhancer(
-                api_key=final_config.get('openai_api_key'),
-                base_url=final_config.get('openai_base_url', 'https://api.openai.com/v1'),
-                model=final_config.get('prompt_enhancement_model', 'gpt-4o-mini')
-            )
-            
             # Enhance and segment the prompt
-            enhancement_result = enhancer.enhance(PROMPT_ENHANCEMENT_INSTRUCTIONS, prompt)
+            enhancement_result = enhance_prompt_data(prompt, final_config)
             
             keyframe_prompts = enhancement_result['keyframe_prompts']
             video_prompts = enhancement_result['video_prompts']
@@ -490,7 +484,11 @@ def execute_pipeline_with_config(
             
             # Stitch segments together
             final_video_path = os.path.join(job_output_dir, "final_video.mp4")
-            stitched_path = stitch_video_segments(video_paths, final_video_path)
+            stitched_path = stitch_video_segments(
+                video_paths,
+                final_video_path,
+                get_trim_duration_seconds(final_config),
+            )
             
             if not stitched_path or not os.path.exists(stitched_path):
                 raise Exception("Failed to stitch video segments")


### PR DESCRIPTION
## Summary

- default direct Vertex generation to `veo-3.1-generate-001`, with `veo-3.1-fast-generate-001` configurable
- send Veo-compatible 4/6/8-second clip durations plus first and last frames through the Google SDK
- add optional CLI `--duration-seconds` and API `duration_seconds`
- constrain and validate prompt decomposition against the requested segment plan
- trim only when the requested runtime cannot be expressed exactly, surfacing the final-keyframe tradeoff

## Impact

Omitting duration preserves AI-inferred runtime. Providing it yields the fewest compatible Veo clips and an exact final runtime. Non-Veo requested-duration planning remains out of scope and returns a validation error rather than pretending provider schemas are interchangeable.

## Validation

- 122 focused Python 3.14 tests passed
- mocked `google-genai` request asserts model, duration, first frame, and last frame
- mocked API-to-worker smoke test verifies duration survives job configuration storage/restoration
- real ffmpeg/ffprobe check produced an exact `9.000000`-second output from a 10-second covering plan
- Python compilation, YAML parsing, CLI help, Ruff on new tests, and `git diff --check` passed