### PR TITLE
feat: add first-class fal and HITL storyboard checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
     *   `runway_ml`: Settings for Runway ML, including `api_key`, `model_version`, etc.
     *   `google_veo`: Settings for Google Veo 3.1, including `project_id`, `credentials_path`, and optional `veo_model` (`veo-3.1-generate-001` by default or `veo-3.1-fast-generate-001`).
     *   `minimax`: Settings for Minimax API, including `api_key`, `model_version`, etc.
-    *   `fal`: Settings for fal.ai, including `api_key`, `model`, optional `base_url`, and optional `default_input`.
+    *   `fal`: Settings for a supported fal.ai model profile, including `api_key`, exact `model` endpoint, queue settings, and validated `default_input` fields. `FAL_KEY` is the preferred environment variable; `FAL_API_KEY` remains compatible.
 
 5.  **Remote API Settings (Common to all remote backends)**:
     *   `max_retries`, `timeout`: General settings for remote API calls.
     *   `fallback_backend`: (Optional) Specify a backend (e.g., "wan2.1", "runway", "minimax", "fal") to use if the `default_backend` (if it's a remote API) fails. If not set, or if the specified fallback also fails, the system may try other available registered backends.
 
-6.  **fal.ai Metrics Output**:
-    *   When `default_backend` is `fal`/`fal.ai`, response headers such as cost and timing are captured when available.
-    *   Metrics are saved next to generated video output as `<output>.metrics.json`.
+6.  **fal.ai Queue Metadata**:
+    *   fal jobs use the durable queue API and expose request ID, exact endpoint ID, queue metrics, billable units, and output metadata on `generator.last_request_metadata`.
+    *   Metadata is intentionally not written beside generated media; persistence and cost analytics are deferred.
 
 7.  **Cost Optimization**:
     *   `max_cost_per_video`, `prefer_local_when_available`.
@@ -153,7 +153,7 @@ All pipeline behavior is controlled through `pipeline_config.yaml`. Copy `pipeli
 
 9.  **Generation Parameters (Applies to all video backends)**:
     *   `segment_duration_seconds`: Desired duration for each video segment in seconds (e.g., 5.0). Crucial for chaining mode.
-    *   `duration_seconds`: Optional requested final runtime for Veo 3.1, up to 14,440 seconds. The pipeline plans 4, 6, or 8 second clips and trims only when no exact sum exists.
+    *   `duration_seconds`: Optional requested final runtime for direct Veo 3.1 or a supported fal profile, up to 14,440 seconds. The pipeline plans provider-compatible clips and trims only when no exact sum exists.
     *   `frame_num`, `sample_steps`, `guide_scale`, `base_seed`, etc.
 
 10.  **Output and Logging Configuration**.

--- a/api/main.py
+++ b/api/main.py
@@ -369,6 +369,7 @@ def setup_routes(app: FastAPI):
     
     # Include job management routes
     app.include_router(jobs.router, prefix="/v1/jobs")
+    app.include_router(jobs.plans_router, prefix="/v1/plans")
     
     # Include health and monitoring routes  
     app.include_router(health.router)

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -554,7 +554,7 @@ class AuthTokenMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app, protected_paths: Optional[Set[str]] = None):
         super().__init__(app)
-        self.protected_paths = protected_paths or {"/v1/jobs"}
+        self.protected_paths = protected_paths or {"/v1/jobs", "/v1/plans"}
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         # Skip CORS preflight

--- a/api/models.py
+++ b/api/models.py
@@ -4,6 +4,7 @@ Pydantic models for API request/response validation and job management.
 
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Optional, List, Dict, Any
 from pydantic import BaseModel, Field, StrictInt, field_validator, model_validator
 
@@ -38,6 +39,14 @@ class VideoPrompt(BaseModel):
     first_frame: Optional[str] = None
     last_frame: Optional[str] = None
     duration_seconds: int
+
+    @field_validator("first_frame", "last_frame")
+    @classmethod
+    def require_frame_filename(cls, value: Optional[str]) -> Optional[str]:
+        paths = (PurePosixPath(value), PureWindowsPath(value)) if value else ()
+        if any(path.name != value for path in paths):
+            raise ValueError("Frame references must be filenames, not paths")
+        return value
 
 
 class PromptEnhancementResult(BaseModel):

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,60 @@ Pydantic models for API request/response validation and job management.
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field, StrictInt, field_validator
+from pydantic import BaseModel, Field, StrictInt, field_validator, model_validator
+
+
+class SegmentationLogic(BaseModel):
+    total_duration_seconds: int
+    number_of_segments: int
+    reasoning: str
+
+
+class ShotTransition(str, Enum):
+    CUT = "cut"
+    CONTINUE = "continue"
+
+
+class KeyframePrompt(BaseModel):
+    segment: int
+    prompt: str
+    transition: ShotTransition = ShotTransition.CONTINUE
+    start_prompt: Optional[str] = None
+
+    @model_validator(mode="after")
+    def require_cut_start_prompt(self):
+        if self.transition == ShotTransition.CUT and not self.start_prompt:
+            raise ValueError("cut keyframes require start_prompt")
+        return self
+
+
+class VideoPrompt(BaseModel):
+    segment: int
+    prompt: str
+    first_frame: Optional[str] = None
+    last_frame: Optional[str] = None
+    duration_seconds: int
+
+
+class PromptEnhancementResult(BaseModel):
+    segmentation_logic: SegmentationLogic
+    keyframe_prompts: List[KeyframePrompt]
+    video_prompts: List[VideoPrompt]
+
+
+class PlanCreateRequest(BaseModel):
+    """Request prompt decomposition without starting paid media generation."""
+
+    prompt: str = Field(..., min_length=1, max_length=100_000)
+    duration_seconds: Optional[StrictInt] = Field(None, gt=0, le=14_440)
+
+    @field_validator("prompt")
+    @classmethod
+    def normalize_prompt(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("Prompt cannot be empty or only whitespace")
+        return value
 
 
 class JobStatus(str, Enum):
@@ -20,8 +73,8 @@ class JobStatus(str, Enum):
 
 class JobCreateRequest(BaseModel):
     """Request model for job creation"""
-    prompt: str = Field(
-        ...,
+    prompt: Optional[str] = Field(
+        None,
         min_length=1,
         max_length=2000,
         description="Text prompt for video generation"
@@ -32,15 +85,31 @@ class JobCreateRequest(BaseModel):
         le=14_440,
         description="Requested final runtime in seconds (currently supported by Veo 3)",
     )
+    enhanced_prompt: Optional[PromptEnhancementResult] = Field(
+        None,
+        description="Reviewed prompt plan returned by POST /v1/plans",
+    )
+    keyframes_only: bool = Field(
+        False,
+        description="Generate and return a keyframe storyboard without video generation",
+    )
     
     @field_validator('prompt')
     @classmethod
     def validate_prompt(cls, v):
+        if v is None:
+            return v
         # Remove excessive whitespace
         v = ' '.join(v.split())
         if not v.strip():
             raise ValueError('Prompt cannot be empty or only whitespace')
         return v
+
+    @model_validator(mode="after")
+    def require_prompt_or_plan(self):
+        if self.prompt is None and self.enhanced_prompt is None:
+            raise ValueError("Either prompt or enhanced_prompt is required")
+        return self
 
 
 class JobCreateResponse(BaseModel):
@@ -59,7 +128,9 @@ class JobStatusResponse(BaseModel):
     created_at: datetime = Field(..., description="Job creation timestamp")
     started_at: Optional[datetime] = Field(None, description="Job start timestamp")
     finished_at: Optional[datetime] = Field(None, description="Job completion timestamp")
-    gcs_uri: Optional[str] = Field(None, description="GCS URI of generated video (when finished)")
+    gcs_uri: Optional[str] = Field(
+        None, description="GCS URI of the generated video or storyboard artifact"
+    )
     error: Optional[str] = Field(None, description="Error message (when failed)")
 
 

--- a/api/queue.py
+++ b/api/queue.py
@@ -139,7 +139,11 @@ class JobQueue:
             id=job_id,
             status=JobStatus.QUEUED,
             created_at=created_at,
-            prompt=request.prompt,
+            prompt=(
+                request.prompt
+                or effective_config.get("prompt")
+                or "Resumed from reviewed prompt plan"
+            ),
             config=redact_config_secrets(effective_config)
         )
         

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -11,11 +11,49 @@ from fastapi import APIRouter, HTTPException, Request
 
 from api.config_merger import ConfigMerger
 from api.logging_config import get_logger
-from api.models import JobCreateRequest, JobCreateResponse, JobStatus, JobStatusResponse
+from api.models import (
+    JobCreateRequest,
+    JobCreateResponse,
+    JobStatus,
+    JobStatusResponse,
+    PlanCreateRequest,
+    PromptEnhancementResult,
+)
 from api.queue import JobQueue
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["jobs"])
+plans_router = APIRouter(tags=["plans"])
+
+
+@plans_router.post(
+    "",
+    response_model=PromptEnhancementResult,
+    response_model_exclude_unset=True,
+)
+async def create_plan(
+    request_obj: Request,
+    request: PlanCreateRequest,
+) -> PromptEnhancementResult:
+    """Create an editable prompt plan without starting media generation."""
+    api_config = getattr(request_obj.app.state, "config", None)
+    if not api_config or not isinstance(api_config.pipeline_config, dict):
+        raise HTTPException(status_code=503, detail="Pipeline configuration not available")
+
+    effective_config = ConfigMerger().merge_for_job(
+        api_config.pipeline_config,
+        request.prompt,
+        request.duration_seconds,
+    )
+
+    from pipeline import enhance_prompt_data
+
+    try:
+        return PromptEnhancementResult.model_validate(
+            enhance_prompt_data(request.prompt, effective_config)
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
 
 
 @router.post("", response_model=JobCreateResponse, status_code=202)
@@ -35,11 +73,23 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
     if not api_config or not isinstance(api_config.pipeline_config, dict):
         raise HTTPException(status_code=503, detail="Pipeline configuration not available")
 
+    job_prompt = request.prompt or "Resumed from reviewed prompt plan"
     effective_config = ConfigMerger().merge_for_job(
         api_config.pipeline_config,
-        request.prompt,
+        job_prompt,
         request.duration_seconds,
     )
+    if request.enhanced_prompt is not None:
+        effective_config["enhanced_prompt"] = request.enhanced_prompt.model_dump(
+            exclude_unset=True
+        )
+    if request.keyframes_only:
+        effective_config["keyframes_only"] = True
+        if effective_config.get("generation_mode", "keyframe").lower() != "keyframe":
+            raise HTTPException(
+                status_code=422,
+                detail="keyframes_only requires generation_mode=keyframe",
+            )
     effective_config.update(
         {
             "gcs_bucket": api_config.gcs.bucket,
@@ -63,7 +113,7 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         job_timeout=job_timeout,
     )
 
-    logger.info(f"Created job {job.id} with prompt: {request.prompt[:50]}...")
+    logger.info(f"Created job {job.id} with prompt: {job_prompt[:50]}...")
 
     return JobCreateResponse(
         id=job.id,

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -98,6 +98,8 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
             )
             if requested_total != generated_total:
                 effective_config["duration_seconds"] = requested_total
+            else:
+                effective_config.pop("duration_seconds", None)
         effective_config["enhanced_prompt"] = reviewed_plan
     if request.keyframes_only:
         effective_config["keyframes_only"] = True

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -4,6 +4,8 @@ Job management routes for the API server.
 This module contains the job creation, status, and management endpoints.
 """
 
+import mimetypes
+import os
 from datetime import datetime, timedelta, timezone
 from typing import List
 
@@ -31,7 +33,7 @@ plans_router = APIRouter(tags=["plans"])
     response_model=PromptEnhancementResult,
     response_model_exclude_unset=True,
 )
-async def create_plan(
+def create_plan(
     request_obj: Request,
     request: PlanCreateRequest,
 ) -> PromptEnhancementResult:
@@ -189,13 +191,14 @@ async def get_job_status(
 
 
 @router.get("/{job_id}/video-url")
-async def get_job_video_url(
+@router.get("/{job_id}/artifact-url")
+async def get_job_artifact_url(
     request_obj: Request,
     job_id: str,
     expiration_seconds: int = 3600
 ) -> dict:
     """
-    Get a signed video URL for a completed job's video.
+    Get a signed URL and media metadata for a completed job artifact.
     
     Returns a time-limited signed URL that can be used to stream or embed the video
     directly from Google Cloud Storage without authentication.
@@ -230,7 +233,7 @@ async def get_job_video_url(
     if not job.gcs_uri:
         raise HTTPException(
             status_code=404, 
-            detail="No video artifact found for this job"
+            detail="No artifact found for this job"
         )
     
     # Create GCS client and generate signed URL
@@ -251,16 +254,22 @@ async def get_job_video_url(
         
         logger.info(f"Generated signed URL for job {job_id}, expires at {expiration_time}")
         
-        return {
-            "video_url": signed_url,
+        artifact_name = os.path.basename(job.gcs_uri)
+        mime_type = mimetypes.guess_type(artifact_name)[0] or "application/octet-stream"
+        response = {
+            "artifact_url": signed_url,
+            "artifact_name": artifact_name,
             "expires_at": expiration_time.isoformat(),
             "expiration_seconds": expiration_seconds,
-            "mime_type": "video/mp4"
+            "mime_type": mime_type,
         }
+        if mime_type.startswith("video/"):
+            response["video_url"] = signed_url
+        return response
         
     except Exception as e:
         logger.error(f"Failed to generate signed URL for job {job_id}: {e}")
         raise HTTPException(
             status_code=500,
-            detail="Failed to generate video URL"
+            detail="Failed to generate artifact URL"
         )

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -87,20 +87,12 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         request.duration_seconds,
     )
     if request.enhanced_prompt is not None:
+        from pipeline import apply_reviewed_plan_config
+
         reviewed_plan = request.enhanced_prompt.model_dump(exclude_unset=True)
-        if request.duration_seconds is None:
-            requested_total = reviewed_plan["segmentation_logic"][
-                "total_duration_seconds"
-            ]
-            generated_total = sum(
-                segment["duration_seconds"]
-                for segment in reviewed_plan["video_prompts"]
-            )
-            if requested_total != generated_total:
-                effective_config["duration_seconds"] = requested_total
-            else:
-                effective_config.pop("duration_seconds", None)
-        effective_config["enhanced_prompt"] = reviewed_plan
+        apply_reviewed_plan_config(
+            effective_config, reviewed_plan, request.duration_seconds
+        )
     if request.keyframes_only:
         effective_config["keyframes_only"] = True
         if effective_config.get("generation_mode", "keyframe").lower() != "keyframe":

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -47,6 +47,11 @@ def create_plan(
         request.prompt,
         request.duration_seconds,
     )
+    if not effective_config.get("openai_api_key") and not os.getenv("OPENAI_API_KEY"):
+        raise HTTPException(
+            status_code=503,
+            detail="Prompt enhancement credentials are not configured",
+        )
 
     from pipeline import enhance_prompt_data
 
@@ -101,9 +106,17 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         }
     )
 
-    from pipeline import get_duration_tradeoff, get_requested_job_timeout
+    from pipeline import (
+        get_duration_tradeoff,
+        get_requested_job_timeout,
+        validate_prompt_enhancement,
+    )
 
     try:
+        if request.enhanced_prompt is not None:
+            validate_prompt_enhancement(
+                effective_config["enhanced_prompt"], effective_config
+            )
         tradeoff = get_duration_tradeoff(effective_config)
         job_timeout = get_requested_job_timeout(effective_config)
     except ValueError as error:

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -87,9 +87,18 @@ async def create_job(request_obj: Request, request: JobCreateRequest) -> JobCrea
         request.duration_seconds,
     )
     if request.enhanced_prompt is not None:
-        effective_config["enhanced_prompt"] = request.enhanced_prompt.model_dump(
-            exclude_unset=True
-        )
+        reviewed_plan = request.enhanced_prompt.model_dump(exclude_unset=True)
+        if request.duration_seconds is None:
+            requested_total = reviewed_plan["segmentation_logic"][
+                "total_duration_seconds"
+            ]
+            generated_total = sum(
+                segment["duration_seconds"]
+                for segment in reviewed_plan["video_prompts"]
+            )
+            if requested_total != generated_total:
+                effective_config["duration_seconds"] = requested_total
+        effective_config["enhanced_prompt"] = reviewed_plan
     if request.keyframes_only:
         effective_config["keyframes_only"] = True
         if effective_config.get("generation_mode", "keyframe").lower() != "keyframe":

--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -98,7 +98,7 @@ The pipeline is configured through `pipeline_config.yaml`, which you must create
    - **Runway ML**: Set `runway_ml.api_key`
    - **Google Veo**: Set `google_veo.project_id` and `credentials_path`
    - **Minimax**: Set `minimax.api_key` or environment variable `MINIMAX_API_KEY`
-   - **fal.ai**: Set `fal.api_key` or environment variable `FAL_API_KEY`, and set `fal.model`
+   - **fal.ai**: Set `fal.api_key` or `FAL_KEY` (`FAL_API_KEY` is a compatibility fallback), and select a profiled `fal.model` endpoint
    - **Stability AI**: Set `stability_api_key`
 
 *Source: [`pipeline_config.yaml.sample`](../pipeline_config.yaml.sample)*

--- a/docs/04-video-generation-backends.md
+++ b/docs/04-video-generation-backends.md
@@ -142,8 +142,8 @@ minimax:
   model: "I2V-01-Director"
 
 fal:
-  api_key: "${FAL_API_KEY}"
-  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
+  api_key: "${FAL_KEY}"
+  model: "bytedance/seedance-2.0/image-to-video"
 ```
 
 ### Backend Selection Logic
@@ -288,8 +288,8 @@ minimax:
 ```yaml
 default_backend: "fal"
 fal:
-  api_key: "${FAL_API_KEY}"
-  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
+  api_key: "${FAL_KEY}"
+  model: "bytedance/seedance-2.0/image-to-video"
 ```
 
 **HunyuanVideo:**

--- a/docs/05-architecture-and-interface.md
+++ b/docs/05-architecture-and-interface.md
@@ -87,9 +87,10 @@ The factory handles backend-specific configuration extraction, mapping general c
 - `google_veo.region`: GCP region for processing
 
 **fal.ai Configuration:**
-- `fal.api_key`: fal.ai API key (or `FAL_API_KEY`)
-- `fal.model`: fal model endpoint ID
-- `fal.default_input`: model-specific input defaults
+- `fal.api_key`: fal.ai API key (or `FAL_KEY`; legacy `FAL_API_KEY` also works)
+- `fal.model`: exact endpoint ID for a tested model profile
+- `fal.default_input`: documented profile fields, validated before submission
+- `fal.queue_start_timeout`: queue-start deadline; total wait uses `remote_api_settings.timeout`
 
 *Source: [`generators/factory.py`](../generators/factory.py)*
 
@@ -169,7 +170,7 @@ graph LR
     minimax --> minimax_max_duration[max_duration]
 
     %% fal.ai Configuration
-    fal --> fal_api_key[api_key or FAL_API_KEY]
+    fal --> fal_api_key[api_key or FAL_KEY]
     fal --> fal_model[model]
     fal --> fal_base_url[base_url]
     fal --> fal_default_input[default_input]

--- a/docs/07-remote-api-generators.md
+++ b/docs/07-remote-api-generators.md
@@ -28,25 +28,27 @@ The remote API generators implement the `VideoGeneratorInterface` to provide vid
 
 ### Provider/Model Separation
 
-The `FalGenerator` treats `fal.ai` as the provider and `fal.model` as the runtime model endpoint, so one backend can target any fal-supported video model.
+The `FalGenerator` treats `fal.ai` as the provider and requires `fal.model` to match a tested endpoint profile. Profiles define exact frame fields, clip lengths, options, and output parsing instead of guessing a shared schema.
 
 **Configuration highlights:**
 - `default_backend`: `"fal"` or `"fal.ai"`
-- `fal.model`: full model endpoint identifier (required)
-- `fal.api_key` or environment variable `FAL_API_KEY`
-- `fal.default_input`: optional model-specific input defaults merged into each request
+- `fal.model`: one of the supported endpoint identifiers listed below
+- `fal.api_key` or environment variable `FAL_KEY` (legacy `FAL_API_KEY` also works)
+- `fal.default_input`: optional documented profile fields; unknown fields are rejected
+- `fal.queue_start_timeout`: server-side deadline for starting work
 
-### Header Metrics Capture
+Supported endpoint profiles:
 
-When fal response headers are present, the generator captures metrics such as:
-- `x-fal-request-id`
-- `x-compute-time`
-- `x-queue-time`
-- `x-total-cost`
-- `x-request-cost`
-- `x-generation-time`
+- `bytedance/seedance-2.0/image-to-video`
+- `bytedance/seedance-2.0/fast/image-to-video`
+- `fal-ai/veo3.1/image-to-video`
+- `fal-ai/veo3.1/first-last-frame-to-video`
+- `fal-ai/veo3.1/fast/image-to-video`
+- `fal-ai/veo3.1/fast/first-last-frame-to-video`
+- `fal-ai/minimax/hailuo-02/standard/image-to-video`
+- `fal-ai/minimax/video-01/image-to-video`
 
-Metrics are written next to the generated file as `<output>.metrics.json`.
+fal requests use `queue.fal.run`: submit once, poll safe lifecycle reads with bounded backoff, retrieve the documented `video.url`, and attempt cancellation on a local timeout. `generator.last_request_metadata` retains request and endpoint identity plus ephemeral queue/output metadata for future reconciliation. It is not persisted to a sidecar.
 
 ## Architecture Overview
 
@@ -506,11 +508,13 @@ minimax:
 **fal.ai Configuration:**
 ```yaml
 fal:
-  api_key: "YOUR_FAL_API_KEY"
-  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"
-  base_url: "https://fal.run"
-  max_duration: 10
-  default_input: {}
+  api_key: "YOUR_FAL_KEY"
+  model: "bytedance/seedance-2.0/image-to-video"
+  base_url: "https://queue.fal.run"
+  queue_start_timeout: 300
+  default_input:
+    resolution: "720p"
+    aspect_ratio: "16:9"
 ```
 
 *Sources: [`generators/remote/runway_generator.py`](../generators/remote/runway_generator.py) (lines 39-56), [`generators/remote/veo3_generator.py`](../generators/remote/veo3_generator.py) (lines 66-82), [`generators/remote/minimax_generator.py`](../generators/remote/minimax_generator.py) (lines 66-82)*
@@ -532,7 +536,8 @@ Both generators support environment variable authentication as fallbacks:
 - **`MINIMAX_API_KEY`**: Minimax API authentication key
 
 **fal.ai Environment Variables:**
-- **`FAL_API_KEY`**: fal.ai API authentication key
+- **`FAL_KEY`**: preferred fal.ai API authentication key
+- **`FAL_API_KEY`**: compatibility fallback
 
 **Environment Variable Priority:**
 1. Configuration file values
@@ -699,8 +704,8 @@ except Exception as e:
 ```python
 config = {
     "api_key": "your_fal_api_key",
-    "model": "fal-ai/minimax/hailuo-02/standard/image-to-video",
-    "base_url": "https://fal.run",
+    "model": "bytedance/seedance-2.0/image-to-video",
+    "base_url": "https://queue.fal.run",
     "timeout": 600,
 }
 
@@ -711,12 +716,11 @@ video_path = generator.generate_video(
     prompt="A cinematic drone shot over neon city streets",
     input_image_path="input.jpg",
     output_path="output.mp4",
-    duration=5.0,
+    duration=12,
 )
 
-# Header metrics (when present) are available in:
-# - generator.last_request_metrics
-# - output.mp4.metrics.json
+# Ephemeral queue and output metadata is available in:
+# generator.last_request_metadata
 ```
 
 ---

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -159,11 +159,13 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
             backend_config = {
                 "api_key": fal_config.get("api_key"),
                 "model": fal_config.get("model"),
-                "base_url": fal_config.get("base_url", "https://fal.run"),
-                "max_duration": fal_config.get("max_duration", 10),
+                "base_url": fal_config.get("base_url", "https://queue.fal.run"),
                 "default_input": fal_config.get("default_input", {}),
                 "max_retries": remote_settings.get("max_retries", 3),
+                "polling_interval": remote_settings.get("polling_interval", 5),
                 "timeout": remote_settings.get("timeout", 600),
+                "http_timeout": remote_settings.get("http_timeout", 30),
+                "queue_start_timeout": fal_config.get("queue_start_timeout", 300),
             }
 
             if not backend_config["model"]:
@@ -171,9 +173,9 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
 
             if not backend_config["api_key"]:
                 import os
-                if not os.getenv("FAL_API_KEY"):
+                if not (os.getenv("FAL_KEY") or os.getenv("FAL_API_KEY")):
                     raise VideoGenerationError(
-                        "fal.ai API key is required but not provided (set config fal.api_key or FAL_API_KEY)"
+                        "fal.ai API key is required but not provided (set config fal.api_key or FAL_KEY)"
                     )
         
         # Create the generator instance

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -140,9 +140,9 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
                 "timeout": remote_settings.get("timeout", 600),
             }
 
-            if not api_key and not backend_config["project_id"]:
+            if use_developer_api and not api_key:
                 raise VideoGenerationError(
-                    "Google Veo 3 requires GOOGLE_API_KEY or a Google Cloud project ID"
+                    "Google Veo 3 Gemini API mode requires GOOGLE_API_KEY or GEMINI_API_KEY"
                 )
         
         elif backend == "minimax":

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -115,22 +115,34 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
             # Google Veo 3 configuration
             veo_config = config.get("google_veo", {})
             remote_settings = config.get("remote_api_settings", {})
-            
+            import os
+
+            project_id = veo_config.get("project_id")
+            veo_model = veo_config.get("veo_model")
+            use_developer_api = not project_id or bool(
+                veo_model and veo_model.endswith("-preview")
+            )
+            api_key = veo_config.get("api_key")
+            if use_developer_api and not api_key:
+                api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+
             backend_config = {
-                "project_id": veo_config.get("project_id"),
+                "api_key": api_key,
+                "project_id": project_id,
                 "credentials_path": veo_config.get("credentials_path", "credentials.json"),
                 "region": veo_config.get("region", "global"),
                 "output_bucket": veo_config.get("output_bucket"),
-                "veo_model": veo_config.get("veo_model", Veo3Generator.MODEL_NAME),
+                "veo_model": veo_model,
                 "video_aspect_ratio": config.get("video_aspect_ratio", "16:9"),
+                "resolution": veo_config.get("resolution", "720p"),
                 "max_retries": remote_settings.get("max_retries", 3),
                 "polling_interval": remote_settings.get("polling_interval", 15),
                 "timeout": remote_settings.get("timeout", 600),
             }
-            
-            if not backend_config["project_id"]:
+
+            if not api_key and not backend_config["project_id"]:
                 raise VideoGenerationError(
-                    "Google Veo 3 requires a project ID"
+                    "Google Veo 3 requires GOOGLE_API_KEY or a Google Cloud project ID"
                 )
         
         elif backend == "minimax":

--- a/generators/factory.py
+++ b/generators/factory.py
@@ -122,7 +122,7 @@ def create_video_generator(backend: str, config: Dict[str, Any]) -> VideoGenerat
             use_developer_api = not project_id or bool(
                 veo_model and veo_model.endswith("-preview")
             )
-            api_key = veo_config.get("api_key")
+            api_key = veo_config.get("api_key") if use_developer_api else None
             if use_developer_api and not api_key:
                 api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
 

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -1,82 +1,230 @@
-"""
-fal.ai video generator implementation.
-
-This backend treats fal.ai as the provider and the model identifier as a
-runtime parameter, so the same generator can target any fal-supported model.
-"""
+"""fal.ai video generation through explicit model profiles and the queue API."""
 
 import base64
-import json
 import os
+import random
+import time
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
-from generators.base import ImageValidator, RetryHandler, download_file
+from generators.base import ImageValidator, download_file
 from video_generator_interface import (
     APIError,
+    GenerationTimeoutError,
     InvalidInputError,
     VideoGenerationError,
     VideoGeneratorInterface,
 )
 
 
+@dataclass(frozen=True)
+class FalModelProfile:
+    endpoint: str
+    durations: tuple[int, ...]
+    duration_encoding: str | None
+    first_frame_field: str
+    last_frame_field: str | None = None
+    max_image_mb: float = 10.0
+    option_values: tuple[tuple[str, tuple[Any, ...] | None], ...] = ()
+    image_endpoint: str | None = None
+    first_last_endpoint: str | None = None
+
+    @property
+    def options(self) -> dict[str, tuple[Any, ...] | None]:
+        return dict(self.option_values)
+
+
+SEEDANCE_DURATIONS = tuple(range(4, 16))
+VEO_DURATIONS = (4, 6, 8)
+
+_SEEDANCE_OPTIONS = (
+    ("resolution", ("480p", "720p", "1080p", "4k")),
+    ("aspect_ratio", ("auto", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16")),
+    ("bitrate_mode", ("standard", "high")),
+    ("end_user_id", None),
+)
+_SEEDANCE_FAST_OPTIONS = (
+    ("resolution", ("480p", "720p")),
+    *_SEEDANCE_OPTIONS[1:],
+)
+_VEO_OPTIONS = (
+    ("aspect_ratio", ("auto", "16:9", "9:16")),
+    ("negative_prompt", None),
+    ("resolution", ("720p", "1080p", "4k")),
+    ("seed", None),
+    ("auto_fix", (True, False)),
+    ("safety_tolerance", (1, 2, 3, 4, 5, 6, "1", "2", "3", "4", "5", "6")),
+)
+
+
+def _veo_profile(endpoint: str, image_endpoint: str, first_last_endpoint: str) -> FalModelProfile:
+    is_first_last = endpoint == first_last_endpoint
+    return FalModelProfile(
+        endpoint=endpoint,
+        durations=VEO_DURATIONS,
+        duration_encoding="seconds",
+        first_frame_field="first_frame_url" if is_first_last else "image_url",
+        last_frame_field="last_frame_url" if is_first_last else None,
+        max_image_mb=8.0,
+        option_values=_VEO_OPTIONS,
+        image_endpoint=image_endpoint,
+        first_last_endpoint=first_last_endpoint,
+    )
+
+
+FAL_MODEL_PROFILES = {
+    "bytedance/seedance-2.0/image-to-video": FalModelProfile(
+        endpoint="bytedance/seedance-2.0/image-to-video",
+        durations=SEEDANCE_DURATIONS,
+        duration_encoding="integer_or_auto",
+        first_frame_field="image_url",
+        last_frame_field="end_image_url",
+        max_image_mb=30.0,
+        option_values=_SEEDANCE_OPTIONS,
+    ),
+    "bytedance/seedance-2.0/fast/image-to-video": FalModelProfile(
+        endpoint="bytedance/seedance-2.0/fast/image-to-video",
+        durations=SEEDANCE_DURATIONS,
+        duration_encoding="integer_or_auto",
+        first_frame_field="image_url",
+        last_frame_field="end_image_url",
+        max_image_mb=30.0,
+        option_values=_SEEDANCE_FAST_OPTIONS,
+    ),
+    "fal-ai/minimax/hailuo-02/standard/image-to-video": FalModelProfile(
+        endpoint="fal-ai/minimax/hailuo-02/standard/image-to-video",
+        durations=(6, 10),
+        duration_encoding="string",
+        first_frame_field="image_url",
+        last_frame_field="end_image_url",
+        option_values=(
+            ("prompt_optimizer", (True, False)),
+            ("resolution", ("512P", "768P")),
+        ),
+    ),
+    "fal-ai/minimax/video-01/image-to-video": FalModelProfile(
+        endpoint="fal-ai/minimax/video-01/image-to-video",
+        durations=(6,),
+        duration_encoding=None,
+        first_frame_field="image_url",
+        option_values=(("prompt_optimizer", (True, False)),),
+    ),
+}
+
+for _prefix in ("fal-ai/veo3.1", "fal-ai/veo3.1/fast"):
+    _image_endpoint = f"{_prefix}/image-to-video"
+    _first_last_endpoint = f"{_prefix}/first-last-frame-to-video"
+    FAL_MODEL_PROFILES[_image_endpoint] = _veo_profile(
+        _image_endpoint, _image_endpoint, _first_last_endpoint
+    )
+    FAL_MODEL_PROFILES[_first_last_endpoint] = _veo_profile(
+        _first_last_endpoint, _image_endpoint, _first_last_endpoint
+    )
+
+
+def get_fal_clip_durations(model: str | None) -> tuple[int, ...]:
+    """Return the allowed clip lengths for a supported fal endpoint."""
+    if model not in FAL_MODEL_PROFILES:
+        supported = ", ".join(sorted(FAL_MODEL_PROFILES))
+        raise ValueError(f"Unsupported fal.ai model endpoint {model!r}. Supported: {supported}")
+    return FAL_MODEL_PROFILES[model].durations
+
+
+def fal_profile_supports_last_frame(model: str | None) -> bool:
+    """Return whether the configured profile can condition on an ending frame."""
+    get_fal_clip_durations(model)
+    assert model is not None
+    profile = FAL_MODEL_PROFILES[model]
+    return bool(profile.last_frame_field or profile.first_last_endpoint)
+
+
 class FalGenerator(VideoGeneratorInterface):
-    """Remote video generator using fal.ai model endpoints."""
+    """Remote video generator using profiled fal.ai queue endpoints."""
 
     def __init__(self, config: dict[str, Any]):
         super().__init__(config)
-        self.api_key = config.get("api_key") or os.getenv("FAL_API_KEY")
-        self.model = config.get("model")
-        self.base_url = config.get("base_url", "https://fal.run").rstrip("/")
-        self.max_duration = config.get("max_duration", 10)
-        self.timeout = config.get("timeout", 600)
-        self.max_retries = config.get("max_retries", 3)
-        self.default_input = config.get("default_input", {})
-        self.last_request_metrics: dict[str, Any] = {}
+        self.api_key = config.get("api_key") or os.getenv("FAL_KEY") or os.getenv("FAL_API_KEY")
+        model = config.get("model")
+        if not isinstance(model, str) or not model:
+            raise VideoGenerationError("fal.ai model is required (set config.fal.model)")
+        self.model = model
+        self.base_url = config.get("base_url", "https://queue.fal.run").rstrip("/")
+        self.timeout = float(config.get("timeout", 600))
+        self.http_timeout = float(config.get("http_timeout", min(30, self.timeout)))
+        self.queue_start_timeout = float(config.get("queue_start_timeout", min(300, self.timeout)))
+        self.polling_interval = float(config.get("polling_interval", 5))
+        self.max_retries = max(1, int(config.get("max_retries", 3)))
+        default_input = config.get("default_input", {})
+        if not isinstance(default_input, dict):
+            raise VideoGenerationError("fal.default_input must be an object")
+        self.default_input = dict(default_input)
+        self.last_request_metadata: dict[str, Any] = {}
 
         if not self.api_key:
-            raise VideoGenerationError("fal.ai API key is required (set config.fal.api_key or FAL_API_KEY)")
-        if not self.model:
-            raise VideoGenerationError("fal.ai model is required (set config.fal.model)")
+            raise VideoGenerationError(
+                "fal.ai API key is required (set config.fal.api_key or FAL_KEY)"
+            )
+        try:
+            get_fal_clip_durations(self.model)
+        except ValueError as exc:
+            raise VideoGenerationError(str(exc)) from exc
+        if self.timeout <= 0 or self.http_timeout <= 0 or self.queue_start_timeout <= 0:
+            raise VideoGenerationError("fal.ai timeouts must be positive")
+        if self.polling_interval < 0:
+            raise VideoGenerationError("fal.ai polling_interval cannot be negative")
 
     def get_capabilities(self) -> dict[str, Any]:
+        profile = FAL_MODEL_PROFILES[self.model]
         return {
             "provider": "fal.ai",
             "model": self.model,
-            "max_duration": self.max_duration,
+            "allowed_durations": list(profile.durations),
+            "max_duration": max(profile.durations),
             "supports_image_to_video": True,
-            "supports_text_to_video": True,
+            "supports_first_last_frame": bool(
+                profile.last_frame_field or profile.first_last_endpoint
+            ),
+            "supports_text_to_video": False,
             "requires_gpu": False,
             "api_based": True,
             "provider_model_separation": True,
-            "header_metrics": [
-                "x-fal-request-id",
-                "x-compute-time",
-                "x-queue-time",
-                "x-total-cost",
-                "x-request-cost",
-            ],
         }
 
     def estimate_cost(self, duration: float, resolution: str = "1280x720") -> float:
-        # fal cost depends on model and provider-side pricing; rely on header metrics when available.
         return 0.0
 
-    def validate_inputs(self, prompt: str, input_image_path: str, duration: float) -> list[str]:
+    def validate_inputs(
+        self, prompt: str, input_image_path: str, duration: float | None
+    ) -> list[str]:
+        profile = FAL_MODEL_PROFILES[self.model]
         errors: list[str] = []
 
-        if not prompt or not prompt.strip():
+        if not isinstance(prompt, str) or not prompt.strip():
             errors.append("Prompt cannot be empty")
 
-        image_validation = ImageValidator.validate_image(input_image_path, max_size_mb=10.0)
-        if not image_validation["valid"]:
-            errors.extend(image_validation["errors"])
+        if not isinstance(input_image_path, str) or not input_image_path:
+            errors.append("Input image path is required")
+        else:
+            image_validation = ImageValidator.validate_image(
+                input_image_path, max_size_mb=profile.max_image_mb
+            )
+            if not image_validation["valid"]:
+                errors.extend(image_validation["errors"])
 
-        if duration <= 0:
-            errors.append("Duration must be positive")
-        elif duration > self.max_duration:
-            errors.append(f"Duration {duration}s exceeds maximum configured duration {self.max_duration}s")
+        if duration is not None:
+            if (
+                isinstance(duration, bool)
+                or not isinstance(duration, (int, float))
+                or duration not in profile.durations
+            ):
+                errors.append(
+                    f"Duration {duration!r}s is unsupported for {self.model}; "
+                    f"use one of {list(profile.durations)}"
+                )
 
         return errors
 
@@ -85,141 +233,326 @@ class FalGenerator(VideoGeneratorInterface):
         prompt: str,
         input_image_path: str,
         output_path: str,
-        duration: float = 5.0,
-        **kwargs,
+        duration: float | None = None,
+        **kwargs: Any,
     ) -> str:
+        self.last_request_metadata = {}
         validation_errors = self.validate_inputs(prompt, input_image_path, duration)
         if validation_errors:
             raise InvalidInputError(f"Input validation failed: {'; '.join(validation_errors)}")
 
-        model = kwargs.get("fal_model") or self.model
-        endpoint = f"{self.base_url}/{model.lstrip('/')}"
+        last_frame_path = kwargs.get("last_frame_path")
+        if last_frame_path is not None and not isinstance(last_frame_path, str):
+            raise InvalidInputError("last_frame_path must be a path string")
+        profile = self._profile_for_request(bool(last_frame_path))
+        if last_frame_path and profile.last_frame_field:
+            last_frame_validation = ImageValidator.validate_image(
+                last_frame_path, max_size_mb=profile.max_image_mb
+            )
+            if not last_frame_validation["valid"]:
+                raise InvalidInputError(
+                    "Last frame validation failed: " + "; ".join(last_frame_validation["errors"])
+                )
 
-        payload: dict[str, Any] = dict(self.default_input)
-        payload.update(kwargs.get("fal_input", {}))
-        payload.update({
+        payload = self._build_payload(
+            profile,
+            prompt,
+            input_image_path,
+            last_frame_path,
+            None if duration is None else int(duration),
+            kwargs.get("fal_input", {}),
+        )
+        headers = self._headers()
+        submit_url = f"{self.base_url}/{profile.endpoint}"
+        deadline = time.monotonic() + self.timeout
+        submission, _ = self._request_json(
+            "POST",
+            submit_url,
+            headers=headers,
+            payload=payload,
+            safe_to_retry=False,
+            deadline=deadline,
+        )
+        lifecycle = self._parse_submission(submission, profile.endpoint)
+        self.last_request_metadata = lifecycle.copy()
+
+        try:
+            status = self._wait_for_completion(lifecycle, headers, deadline)
+            result, response = self._request_json(
+                "GET",
+                lifecycle["response_url"],
+                headers=headers,
+                safe_to_retry=True,
+                deadline=deadline,
+            )
+        except GenerationTimeoutError, KeyboardInterrupt:
+            self._cancel(lifecycle["cancel_url"], headers)
+            raise
+
+        video = result.get("video")
+        if not isinstance(video, dict) or not isinstance(video.get("url"), str):
+            raise VideoGenerationError("fal.ai response did not contain video.url")
+
+        self.last_request_metadata.update(
+            {
+                "status": "COMPLETED",
+                "metrics": status.get("metrics", {}),
+                "video": {
+                    key: video[key]
+                    for key in ("content_type", "file_name", "file_size")
+                    if key in video
+                },
+            }
+        )
+        if "seed" in result:
+            self.last_request_metadata["seed"] = result["seed"]
+        billable_units = self._header(response.headers, "X-Fal-Billable-Units")
+        if billable_units is not None:
+            self.last_request_metadata["billable_units"] = billable_units
+
+        download_file(video["url"], output_path)
+        return output_path
+
+    def is_available(self) -> bool:
+        return bool(self.api_key and self.model in FAL_MODEL_PROFILES)
+
+    def _profile_for_request(self, has_last_frame: bool) -> FalModelProfile:
+        profile = FAL_MODEL_PROFILES[self.model]
+        endpoint = (
+            profile.first_last_endpoint
+            if has_last_frame and profile.first_last_endpoint
+            else (
+                profile.image_endpoint
+                if not has_last_frame and profile.image_endpoint
+                else profile.endpoint
+            )
+        )
+        return FAL_MODEL_PROFILES[endpoint]
+
+    def _build_payload(
+        self,
+        profile: FalModelProfile,
+        prompt: str,
+        input_image_path: str,
+        last_frame_path: str | None,
+        duration: int | None,
+        request_input: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not isinstance(request_input, dict):
+            raise InvalidInputError("fal_input must be an object")
+        options = {**self.default_input, **request_input}
+        unsupported = sorted(set(options) - set(profile.options))
+        if unsupported:
+            raise InvalidInputError(
+                f"Unsupported fal.ai input fields for {profile.endpoint}: {unsupported}"
+            )
+        for name, allowed in profile.options.items():
+            if name in options and allowed is not None and options[name] not in allowed:
+                raise InvalidInputError(
+                    f"Unsupported {name}={options[name]!r} for {profile.endpoint}; "
+                    f"use one of {list(allowed)}"
+                )
+
+        payload = {
+            **options,
             "prompt": prompt,
-            "image_url": self._image_to_data_uri(input_image_path),
-            "duration": duration,
-        })
+            profile.first_frame_field: self._image_to_data_uri(input_image_path),
+        }
+        if last_frame_path and profile.last_frame_field:
+            payload[profile.last_frame_field] = self._image_to_data_uri(last_frame_path)
+        if profile.duration_encoding == "integer_or_auto":
+            payload["duration"] = "auto" if duration is None else duration
+        elif duration is not None and profile.duration_encoding == "seconds":
+            payload["duration"] = f"{duration}s"
+        elif duration is not None and profile.duration_encoding == "string":
+            payload["duration"] = str(duration)
+        return payload
 
-        headers = {
+    def _headers(self) -> dict[str, str]:
+        return {
             "Authorization": f"Key {self.api_key}",
             "Content-Type": "application/json",
             "Accept": "application/json",
+            "X-Fal-Request-Timeout": str(self.queue_start_timeout),
+            "X-Fal-Store-IO": "0",
+            "x-app-fal-disable-fallback": "true",
         }
 
-        retry_handler = RetryHandler(max_retries=self.max_retries)
-
-        def _generate_attempt() -> str:
-            response = requests.post(endpoint, headers=headers, json=payload, timeout=self.timeout)
-
-            if response.status_code == 401:
-                raise APIError("fal.ai authentication failed", status_code=401)
-            if response.status_code == 429:
-                raise APIError("fal.ai rate limit exceeded", status_code=429)
-            if response.status_code >= 400:
-                raise APIError(
-                    f"fal.ai request failed with status {response.status_code}",
-                    status_code=response.status_code,
-                    response_body=response.text,
-                )
-
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        payload: dict[str, Any] | None = None,
+        safe_to_retry: bool,
+        deadline: float | None = None,
+    ) -> tuple[dict[str, Any], requests.Response]:
+        for attempt in range(self.max_retries):
             try:
-                response_json = response.json()
-            except json.JSONDecodeError as exc:
-                raise APIError("fal.ai returned non-JSON response") from exc
+                request_timeout = self.http_timeout
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise GenerationTimeoutError(
+                            f"fal.ai generation timed out after {self.timeout:g} seconds"
+                        )
+                    request_timeout = min(request_timeout, remaining)
+                response = requests.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=payload,
+                    timeout=request_timeout,
+                )
+            except requests.RequestException as exc:
+                if not safe_to_retry or attempt == self.max_retries - 1:
+                    message = (
+                        "fal.ai submission outcome is unknown and was not retried"
+                        if method == "POST"
+                        else "fal.ai queue request failed"
+                    )
+                    raise APIError(message) from exc
+                self._sleep_before_retry(attempt, None)
+                continue
 
-            self.last_request_metrics = self._extract_response_metrics(response.headers)
-            if self.last_request_metrics:
-                self.logger.info(f"fal.ai response metrics: {self.last_request_metrics}")
+            if response.status_code < 400:
+                try:
+                    data = response.json()
+                except ValueError as exc:
+                    raise APIError("fal.ai returned a non-JSON response") from exc
+                if not isinstance(data, dict):
+                    raise APIError("fal.ai returned an invalid JSON response")
+                return data, response
 
-            video_url = self._extract_video_url(response_json)
-            download_file(video_url, output_path)
-            self._write_metrics_sidecar(output_path)
-            return output_path
+            retryable = self._is_retryable(response)
+            if retryable and attempt < self.max_retries - 1:
+                self._sleep_before_retry(attempt, response)
+                continue
+            raise self._api_error(response)
 
-        return retry_handler.retry_with_backoff(_generate_attempt)
+        raise APIError("fal.ai queue request failed")  # pragma: no cover
 
-    def is_available(self) -> bool:
-        return bool(self.api_key and self.model)
+    def _wait_for_completion(
+        self,
+        lifecycle: dict[str, Any],
+        headers: dict[str, str],
+        deadline: float,
+    ) -> dict[str, Any]:
+        while True:
+            status, _ = self._request_json(
+                "GET",
+                lifecycle["status_url"],
+                headers=headers,
+                safe_to_retry=True,
+                deadline=deadline,
+            )
+            state = status.get("status")
+            self.last_request_metadata["status"] = state
+            if state == "COMPLETED":
+                if status.get("error") or status.get("error_type"):
+                    raise APIError(
+                        f"fal.ai generation failed: {status.get('error') or status.get('error_type')}",
+                        error_type=status.get("error_type"),
+                    )
+                return status
+            if state not in {"IN_QUEUE", "IN_PROGRESS"}:
+                raise APIError(f"fal.ai returned unknown queue status {state!r}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise GenerationTimeoutError(
+                    f"fal.ai generation timed out after {self.timeout:g} seconds"
+                )
+            time.sleep(min(self.polling_interval, remaining))
 
-    def _image_to_data_uri(self, image_path: str) -> str:
-        with open(image_path, "rb") as image_file:
-            data = base64.b64encode(image_file.read()).decode("utf-8")
-        mime_type = "image/png" if image_path.lower().endswith(".png") else "image/jpeg"
-        return f"data:{mime_type};base64,{data}"
+    def _parse_submission(self, submission: dict[str, Any], endpoint: str) -> dict[str, Any]:
+        required = ("request_id", "status_url", "response_url", "cancel_url")
+        missing = [name for name in required if not submission.get(name)]
+        if missing:
+            raise APIError(f"fal.ai queue submission omitted fields: {missing}")
+        for name in required[1:]:
+            self._validate_lifecycle_url(submission[name])
+        return {
+            "request_id": submission["request_id"],
+            "endpoint_id": endpoint,
+            "status_url": submission["status_url"],
+            "response_url": submission["response_url"],
+            "cancel_url": submission["cancel_url"],
+        }
 
-    def _extract_video_url(self, payload: Any) -> str:
-        url = self._find_first_url(payload)
-        if not url:
-            raise VideoGenerationError("No downloadable URL found in fal.ai response")
-        return url
+    def _validate_lifecycle_url(self, url: str) -> None:
+        expected = urlparse(self.base_url)
+        actual = urlparse(url)
+        if (actual.scheme, actual.netloc) != (expected.scheme, expected.netloc):
+            raise APIError("fal.ai returned an untrusted queue lifecycle URL")
 
-    def _find_first_url(self, value: Any) -> str | None:
-        if isinstance(value, dict):
-            for key in ("video", "video_url", "url", "file", "output"):
-                if key in value:
-                    result = self._find_first_url(value[key])
-                    if result:
-                        return result
-            for nested in value.values():
-                result = self._find_first_url(nested)
-                if result:
-                    return result
+    def _cancel(self, cancel_url: str, headers: dict[str, str]) -> None:
+        try:
+            requests.put(cancel_url, headers=headers, timeout=self.http_timeout)
+            self.last_request_metadata["cancellation_requested"] = True
+        except requests.RequestException:
+            self.last_request_metadata["cancellation_requested"] = False
+
+    def _sleep_before_retry(self, attempt: int, response: requests.Response | None) -> None:
+        retry_after = self._retry_after(response) if response is not None else None
+        delay = retry_after if retry_after is not None else min(2**attempt, 30)
+        time.sleep(delay + random.uniform(0, min(1.0, delay * 0.25)))
+
+    def _retry_after(self, response: requests.Response) -> float | None:
+        value = self._header(response.headers, "Retry-After")
+        if value is None:
             return None
+        try:
+            return max(0.0, float(value))
+        except TypeError, ValueError:
+            try:
+                return max(0.0, parsedate_to_datetime(str(value)).timestamp() - time.time())
+            except TypeError, ValueError, OverflowError:
+                return None
 
-        if isinstance(value, list):
-            for item in value:
-                result = self._find_first_url(item)
-                if result:
-                    return result
-            return None
+    def _is_retryable(self, response: requests.Response) -> bool:
+        if response.status_code in {400, 401, 403, 404, 422}:
+            return False
+        needs_retry = str(self._header(response.headers, "X-Fal-Needs-Retry") or "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        return response.status_code in {429, 500, 502, 503, 504} or needs_retry
 
-        if isinstance(value, str) and value.startswith(("http://", "https://")):
-            return value
-        return None
-
-    def _extract_response_metrics(self, headers: dict[str, Any]) -> dict[str, Any]:
-        metrics: dict[str, Any] = {}
-
-        request_id = headers.get("x-fal-request-id")
-        if request_id:
-            metrics["request_id"] = request_id
-
-        for header_key, metric_key in {
-            "x-compute-time": "compute_time",
-            "x-queue-time": "queue_time",
-            "x-total-cost": "total_cost",
-            "x-request-cost": "request_cost",
-            "x-generation-time": "generation_time",
-        }.items():
-            value = headers.get(header_key)
-            if value is not None:
-                metrics[metric_key] = self._parse_numeric(value)
-
-        return metrics
+    def _api_error(self, response: requests.Response) -> APIError:
+        try:
+            body = response.json()
+        except ValueError:
+            body = {}
+        error_type = self._header(response.headers, "X-Fal-Error-Type")
+        if isinstance(body, dict):
+            error_type = body.get("error_type") or error_type
+            detail = body.get("detail") or body.get("error") or body.get("message")
+        else:
+            detail = None
+        message = f"fal.ai request failed with status {response.status_code}"
+        if detail:
+            message += f": {str(detail)[:1000]}"
+        return APIError(
+            message,
+            status_code=response.status_code,
+            response_body=str(detail)[:1000] if detail else None,
+            error_type=error_type,
+        )
 
     @staticmethod
-    def _parse_numeric(value: Any) -> Any:
-        if isinstance(value, (int, float)):
-            return value
-        if not isinstance(value, str):
-            return value
-        try:
-            if "." in value:
-                return float(value)
-            return int(value)
-        except ValueError:
-            return value
+    def _header(headers: Any, name: str) -> Any:
+        lowered = name.lower()
+        return next((value for key, value in headers.items() if str(key).lower() == lowered), None)
 
-    def _write_metrics_sidecar(self, output_path: str) -> None:
-        if not self.last_request_metrics:
-            return
-
-        sidecar_path = f"{output_path}.metrics.json"
-        try:
-            with open(sidecar_path, "w") as sidecar_file:
-                json.dump(self.last_request_metrics, sidecar_file, indent=2)
-        except Exception as exc:  # pragma: no cover
-            self.logger.warning(f"Failed to write fal.ai metrics sidecar: {exc}")
+    @staticmethod
+    def _image_to_data_uri(image_path: str) -> str:
+        with open(image_path, "rb") as image_file:
+            data = base64.b64encode(image_file.read()).decode("utf-8")
+        extension = os.path.splitext(image_path)[1].lower()
+        mime_type = {
+            ".png": "image/png",
+            ".webp": "image/webp",
+        }.get(extension, "image/jpeg")
+        return f"data:{mime_type};base64,{data}"

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -277,9 +277,12 @@ class FalGenerator(VideoGeneratorInterface):
         )
         lifecycle = self._parse_submission(submission, profile.endpoint)
         self.last_request_metadata = lifecycle.copy()
+        cancellation_check = kwargs.get("cancellation_check")
 
         try:
-            status = self._wait_for_completion(lifecycle, headers, deadline)
+            status = self._wait_for_completion(
+                lifecycle, headers, deadline, cancellation_check
+            )
             result, response = self._request_json(
                 "GET",
                 lifecycle["response_url"],
@@ -287,7 +290,7 @@ class FalGenerator(VideoGeneratorInterface):
                 safe_to_retry=True,
                 deadline=deadline,
             )
-        except (GenerationTimeoutError, KeyboardInterrupt):
+        except (GenerationTimeoutError, InterruptedError, KeyboardInterrupt):
             self._cancel(lifecycle["cancel_url"], headers)
             raise
 
@@ -440,8 +443,11 @@ class FalGenerator(VideoGeneratorInterface):
         lifecycle: dict[str, Any],
         headers: dict[str, str],
         deadline: float,
+        cancellation_check=None,
     ) -> dict[str, Any]:
         while True:
+            if cancellation_check and cancellation_check():
+                raise InterruptedError("fal.ai generation cancelled")
             status, _ = self._request_json(
                 "GET",
                 lifecycle["status_url"],

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -47,6 +47,7 @@ _SEEDANCE_OPTIONS = (
     ("generate_audio", (True, False)),
     ("bitrate_mode", ("standard", "high")),
     ("end_user_id", None),
+    ("seed", None),
 )
 _SEEDANCE_FAST_OPTIONS = (
     ("resolution", ("480p", "720p")),
@@ -411,6 +412,10 @@ class FalGenerator(VideoGeneratorInterface):
                     timeout=request_timeout,
                 )
             except requests.RequestException as exc:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise GenerationTimeoutError(
+                        f"fal.ai generation timed out after {self.timeout:g} seconds"
+                    ) from exc
                 if not safe_to_retry or attempt == self.max_retries - 1:
                     message = (
                         "fal.ai submission outcome is unknown and was not retried"

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -285,7 +285,7 @@ class FalGenerator(VideoGeneratorInterface):
                 safe_to_retry=True,
                 deadline=deadline,
             )
-        except GenerationTimeoutError, KeyboardInterrupt:
+        except (GenerationTimeoutError, KeyboardInterrupt):
             self._cancel(lifecycle["cancel_url"], headers)
             raise
 
@@ -413,7 +413,7 @@ class FalGenerator(VideoGeneratorInterface):
                         else "fal.ai queue request failed"
                     )
                     raise APIError(message) from exc
-                self._sleep_before_retry(attempt, None)
+                self._sleep_before_retry(attempt, None, deadline)
                 continue
 
             if response.status_code < 400:
@@ -427,7 +427,7 @@ class FalGenerator(VideoGeneratorInterface):
 
             retryable = self._is_retryable(response)
             if retryable and attempt < self.max_retries - 1:
-                self._sleep_before_retry(attempt, response)
+                self._sleep_before_retry(attempt, response, deadline)
                 continue
             raise self._api_error(response)
 
@@ -493,10 +493,20 @@ class FalGenerator(VideoGeneratorInterface):
         except requests.RequestException:
             self.last_request_metadata["cancellation_requested"] = False
 
-    def _sleep_before_retry(self, attempt: int, response: requests.Response | None) -> None:
+    def _sleep_before_retry(
+        self,
+        attempt: int,
+        response: requests.Response | None,
+        deadline: float | None = None,
+    ) -> None:
         retry_after = self._retry_after(response) if response is not None else None
         delay = retry_after if retry_after is not None else min(2**attempt, 30)
-        time.sleep(delay + random.uniform(0, min(1.0, delay * 0.25)))
+        delay += random.uniform(0, min(1.0, delay * 0.25))
+        if deadline is not None and delay >= deadline - time.monotonic():
+            raise GenerationTimeoutError(
+                f"fal.ai generation timed out after {self.timeout:g} seconds"
+            )
+        time.sleep(delay)
 
     def _retry_after(self, response: requests.Response) -> float | None:
         value = self._header(response.headers, "Retry-After")
@@ -504,10 +514,10 @@ class FalGenerator(VideoGeneratorInterface):
             return None
         try:
             return max(0.0, float(value))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             try:
                 return max(0.0, parsedate_to_datetime(str(value)).timestamp() - time.time())
-            except TypeError, ValueError, OverflowError:
+            except (TypeError, ValueError, OverflowError):
                 return None
 
     def _is_retryable(self, response: requests.Response) -> bool:

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -53,6 +53,7 @@ _SEEDANCE_FAST_OPTIONS = (
 )
 _VEO_OPTIONS = (
     ("aspect_ratio", ("auto", "16:9", "9:16")),
+    ("generate_audio", (True, False)),
     ("negative_prompt", None),
     ("resolution", ("720p", "1080p", "4k")),
     ("seed", None),

--- a/generators/remote/fal_generator.py
+++ b/generators/remote/fal_generator.py
@@ -44,6 +44,7 @@ VEO_DURATIONS = (4, 6, 8)
 _SEEDANCE_OPTIONS = (
     ("resolution", ("480p", "720p", "1080p", "4k")),
     ("aspect_ratio", ("auto", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16")),
+    ("generate_audio", (True, False)),
     ("bitrate_mode", ("standard", "high")),
     ("end_user_id", None),
 )

--- a/generators/remote/minimax_generator.py
+++ b/generators/remote/minimax_generator.py
@@ -28,6 +28,9 @@ from generators.base import (
 
 class MinimaxGenerator(VideoGeneratorInterface):
     """Remote video generator using Minimax API with I2V-01-Director model"""
+
+    DEFAULT_MAX_DURATION = 6
+    MAX_PROMPT_LENGTH = 500
     
     # Pricing per second (estimated based on typical I2V pricing)
     PRICING = {
@@ -45,7 +48,7 @@ class MinimaxGenerator(VideoGeneratorInterface):
         super().__init__(config)
         self.api_key = config.get("api_key")
         self.model = config.get("model", "I2V-01-Director")
-        self.max_duration = config.get("max_duration", 6)  # Minimax typical max
+        self.max_duration = config.get("max_duration", self.DEFAULT_MAX_DURATION)
         self.base_url = config.get("base_url", "https://api.minimaxi.chat/v1")
         self.max_retries = config.get("max_retries", 3)
         self.polling_interval = config.get("polling_interval", 30)  # Poll every 30 seconds
@@ -79,7 +82,7 @@ class MinimaxGenerator(VideoGeneratorInterface):
             "api_based": True,
             "supports_camera_movements": True,
             "camera_movements": self.CAMERA_MOVEMENTS,
-            "max_prompt_length": 500,
+            "max_prompt_length": self.MAX_PROMPT_LENGTH,
             "cost_per_second": self.PRICING.get(self.model, 0.02)
         }
     
@@ -98,8 +101,10 @@ class MinimaxGenerator(VideoGeneratorInterface):
         # Validate prompt
         if not prompt or len(prompt.strip()) == 0:
             errors.append("Prompt cannot be empty")
-        elif len(prompt) > 500:
-            errors.append("Prompt too long (max 500 characters for Minimax)")
+        elif len(prompt) > self.MAX_PROMPT_LENGTH:
+            errors.append(
+                f"Prompt too long (max {self.MAX_PROMPT_LENGTH} characters for Minimax)"
+            )
         
         # Validate image
         image_validation = ImageValidator.validate_image(input_image_path, max_size_mb=10.0)

--- a/generators/remote/veo3_generator.py
+++ b/generators/remote/veo3_generator.py
@@ -190,7 +190,10 @@ class Veo3Generator(VideoGeneratorInterface):
                             f"Recommended: 16:9, 9:16, or 1:1")
         
         # Validate duration
-        if duration not in self.SUPPORTED_DURATIONS:
+        resolution = self.config.get("resolution", "720p")
+        if resolution in {"1080p", "4k"} and duration != 8:
+            errors.append(f"{resolution} Veo generation requires an 8-second duration")
+        elif duration not in self.SUPPORTED_DURATIONS:
             errors.append(f"Duration must be one of {self.SUPPORTED_DURATIONS} seconds")
         
         return errors

--- a/generators/remote/veo3_generator.py
+++ b/generators/remote/veo3_generator.py
@@ -46,29 +46,36 @@ from generators.base import (
 class Veo3Generator(VideoGeneratorInterface):
     """Remote video generator using Google Veo 3 API"""
     
-    # Model name for Veo 3
+    # Vertex AI and Gemini Developer API model names.
     MODEL_NAME = "veo-3.1-generate-001"
+    API_MODEL_NAME = "veo-3.1-generate-preview"
     SUPPORTED_DURATIONS = [4, 6, 8]
     
-    # Pricing estimates (placeholder values - actual pricing TBD)
     PRICING = {
-        "veo-3.1-generate-001": 0.75,
+        "veo-3.1-generate-001": 0.50,
+        "veo-3.1-fast-generate-001": 0.50,
+        "veo-3.1-generate-preview": 0.40,
+        "veo-3.1-fast-generate-preview": 0.10,
+        "veo-3.1-lite-generate-preview": 0.05,
     }
     
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
+        self.api_key = config.get("api_key")
         self.project_id = config.get("project_id")
         self.region = config.get("region", "global")  # Veo 3 is available in global region
         self.credentials_path = config.get("credentials_path", "credentials.json")
         self.output_bucket = config.get("output_bucket")
         self.max_retries = config.get("max_retries", 3)
         self.timeout = config.get("timeout", 600)
-        self.model_name = config.get("veo_model", self.MODEL_NAME)  # Use config model or fallback to default
+        self.model_name = config.get("veo_model") or (
+            self.API_MODEL_NAME if self.api_key else self.MODEL_NAME
+        )
         
-        if not self.project_id:
-            raise VideoGenerationError("Google Cloud project ID is required")
+        if not self.api_key and not self.project_id:
+            raise VideoGenerationError("Google API key or Google Cloud project ID is required")
         
-        if not self.output_bucket:
+        if not self.api_key and not self.output_bucket:
             self.output_bucket = f"{self.project_id}-veo3-outputs"
             self.logger.info(f"No output bucket specified, using default: {self.output_bucket}")
         
@@ -81,6 +88,12 @@ class Veo3Generator(VideoGeneratorInterface):
     def _init_clients(self):
         """Initialize Google Cloud clients"""
         try:
+            if self.api_key:
+                self.genai_client = genai.Client(api_key=self.api_key)
+                self.storage_client = None
+                self.logger.info("Gemini Developer API client initialized successfully")
+                return
+
             # Set environment variables for Google Gen AI SDK
             os.environ["GOOGLE_CLOUD_PROJECT"] = self.project_id
             os.environ["GOOGLE_CLOUD_LOCATION"] = self.region
@@ -131,18 +144,8 @@ class Veo3Generator(VideoGeneratorInterface):
     
     def estimate_cost(self, duration: float, resolution: str = "1920x1080") -> float:
         """Estimate cost for video generation"""
-        # Get price per second for the model
         price_per_second = self.PRICING.get(self.model_name, 0.10)
-        
-        # Resolution multiplier
-        resolution_multipliers = {
-            "1024x1024": 1.0,
-            "1920x1080": 1.2,
-            "1080x1920": 1.2
-        }
-        multiplier = resolution_multipliers.get(resolution, 1.0)
-        
-        return duration * price_per_second * multiplier
+        return duration * price_per_second
     
     def validate_inputs(self, 
                        prompt: str, 
@@ -230,16 +233,10 @@ class Veo3Generator(VideoGeneratorInterface):
         self.logger.info(f"Using video aspect ratio: {video_aspect_ratio}")
         
         try:
-            # Create a unique output GCS URI for this generation
-            output_gcs_uri = self._create_output_gcs_uri()
-            
-            # Ensure the output bucket exists
-            self._ensure_bucket_exists(self.output_bucket)
-            
             def request_image(path):
                 mime_type, _ = mimetypes.guess_type(path)
                 mime_type = mime_type or "image/jpeg"
-                if kwargs.get("use_local_file", False):
+                if self.api_key or kwargs.get("use_local_file", False):
                     return GenAIImage.from_file(location=path, mime_type=mime_type)
                 return GenAIImage(gcs_uri=self._upload_to_gcs(path), mime_type=mime_type)
 
@@ -250,24 +247,41 @@ class Veo3Generator(VideoGeneratorInterface):
             self.logger.info(f"Submitting video generation request to {self.model_name}...")
             
             # Create the configuration
-            config = GenerateVideosConfig(
-                aspect_ratio=video_aspect_ratio,
-                duration_seconds=int(duration),
-                last_frame=last_frame,
-                output_gcs_uri=output_gcs_uri,
-            )
+            config_args = {
+                "aspect_ratio": video_aspect_ratio,
+                "duration_seconds": int(duration),
+                "last_frame": last_frame,
+            }
+            if self.api_key:
+                config_args.update(
+                    resolution=self.config.get("resolution", "720p"),
+                    person_generation="allow_adult",
+                )
+            else:
+                output_gcs_uri = self._create_output_gcs_uri()
+                self._ensure_bucket_exists(self.output_bucket)
+                config_args["output_gcs_uri"] = output_gcs_uri
+            config = GenerateVideosConfig(**config_args)
             
             # Use the asynchronous API call and wait for completion
             progress_monitor = ProgressMonitor(100)
             progress_monitor.update(0, "Submitting video generation request...")
             
-            operation = self.retry_handler.retry_with_backoff(
-                self.genai_client.models.generate_videos,
-                model=self.model_name,
-                image=image,
-                prompt=prompt,
-                config=config
-            )
+            request_args = {
+                "model": self.model_name,
+                "image": image,
+                "prompt": prompt,
+                "config": config,
+            }
+            if self.api_key:
+                # The Developer API reports invalid model/parameter combinations as
+                # HTTP 400. Repeating the same paid-generation request cannot recover.
+                operation = self.genai_client.models.generate_videos(**request_args)
+            else:
+                operation = self.retry_handler.retry_with_backoff(
+                    self.genai_client.models.generate_videos,
+                    **request_args,
+                )
             
             # Poll the operation until completion
             start_time = time.time()
@@ -282,8 +296,15 @@ class Veo3Generator(VideoGeneratorInterface):
             self.logger.info(f"Video generation completed in {format_duration(elapsed)}")
             progress_monitor.update(100, "Video generation complete")
             
-            # Extract the video URI from the operation result
-            if operation.response and hasattr(operation.result, 'generated_videos') and operation.result.generated_videos:
+            response = operation.response
+            if self.api_key and response and response.generated_videos:
+                video = response.generated_videos[0].video
+                self.genai_client.files.download(file=video)
+                video.save(output_path)
+                return output_path
+
+            # Extract the Vertex output URI from the operation result.
+            if response and hasattr(operation.result, 'generated_videos') and operation.result.generated_videos:
                 video_uri = operation.result.generated_videos[0].video.uri
                 if video_uri:
                     self.logger.info(f"Video generated successfully: {video_uri}")
@@ -402,7 +423,7 @@ class Veo3Generator(VideoGeneratorInterface):
         """Check if Veo 3 API is available"""
         try:
             # Check if credentials are valid and we have basic requirements
-            if not self.project_id:
+            if not self.api_key and not self.project_id:
                 return False
             
             # Simple connectivity check - just verify we can access the client

--- a/generators/remote/veo3_generator.py
+++ b/generators/remote/veo3_generator.py
@@ -48,7 +48,9 @@ class Veo3Generator(VideoGeneratorInterface):
     
     # Vertex AI and Gemini Developer API model names.
     MODEL_NAME = "veo-3.1-generate-001"
+    FAST_MODEL_NAME = "veo-3.1-fast-generate-001"
     API_MODEL_NAME = "veo-3.1-generate-preview"
+    API_FAST_MODEL_NAME = "veo-3.1-fast-generate-preview"
     SUPPORTED_DURATIONS = [4, 6, 8]
     
     PRICING = {
@@ -68,7 +70,17 @@ class Veo3Generator(VideoGeneratorInterface):
         self.output_bucket = config.get("output_bucket")
         self.max_retries = config.get("max_retries", 3)
         self.timeout = config.get("timeout", 600)
-        self.model_name = config.get("veo_model") or (
+        configured_model = config.get("veo_model")
+        if self.api_key and configured_model:
+            configured_model = {
+                self.MODEL_NAME: self.API_MODEL_NAME,
+                self.FAST_MODEL_NAME: self.API_FAST_MODEL_NAME,
+            }.get(configured_model, configured_model)
+            if configured_model not in {self.API_MODEL_NAME, self.API_FAST_MODEL_NAME}:
+                raise VideoGenerationError(
+                    f"Unsupported Gemini API Veo model: {configured_model}"
+                )
+        self.model_name = configured_model or (
             self.API_MODEL_NAME if self.api_key else self.MODEL_NAME
         )
         

--- a/keyframe_generator.py
+++ b/keyframe_generator.py
@@ -18,7 +18,7 @@ import requests
 from typing import Optional, Dict, Any
 import time
 
-from PIL import Image
+from PIL import Image, ImageOps
 from google import genai
 from google.genai import types
 
@@ -455,7 +455,6 @@ def generate_keyframe_with_gemini(
                     if os.path.exists(image_path):
                         # Validate that the reference image is valid before using it
                         try:
-                            from PIL import Image
                             img = Image.open(image_path)
                             img.verify()  # Verify it's a valid image
                             with open(image_path, "rb") as f:
@@ -478,7 +477,6 @@ def generate_keyframe_with_gemini(
         if input_image_path and os.path.exists(input_image_path):
             # Validate that the input image is valid before using it
             try:
-                from PIL import Image
                 img = Image.open(input_image_path)
                 img.verify()  # Verify it's a valid image
                 logging.info(f"Using input image for I2I: {input_image_path}")
@@ -555,14 +553,32 @@ def generate_keyframe_with_gemini(
                         
                         # Create directory if it doesn't exist
                         os.makedirs(os.path.dirname(output_path), exist_ok=True)
-                        
-                        # Save the image
-                        with open(output_path, "wb") as f:
-                            f.write(image_bytes)
+
+                        # The API may return JPEG bytes for a requested .png path.
+                        # Normalize the bytes so downstream MIME detection is truthful.
+                        image = Image.open(io.BytesIO(image_bytes))
+                        image.load()
+                        if input_image_path and os.path.exists(input_image_path):
+                            with Image.open(input_image_path) as input_image:
+                                expected_size = input_image.size
+                            if image.size != expected_size:
+                                logging.info(
+                                    "Normalizing edited frame from %s to %s",
+                                    image.size,
+                                    expected_size,
+                                )
+                                image = ImageOps.fit(
+                                    image,
+                                    expected_size,
+                                    method=Image.Resampling.LANCZOS,
+                                )
+                        if Path(output_path).suffix.lower() == ".png":
+                            image.save(output_path, format="PNG")
+                        else:
+                            image.save(output_path)
                         
                         # Validate that the saved image is valid
                         try:
-                            from PIL import Image
                             img = Image.open(output_path)
                             img.verify()  # Verify it's a valid image
                             logging.info(f"Image saved and verified: {output_path}")
@@ -738,10 +754,12 @@ def generate_keyframes_from_json(json_file, output_dir, model_name=None, imageRo
     # Variable to track the previous image path for sequential generation
     prev_image_path = initial_image_path
     
-    # Generate each keyframe sequentially, using the previous keyframe as input
+    # Continue within a scene; reset image conditioning at explicit cuts.
     for item in sorted(data["keyframe_prompts"], key=lambda x: x.get("segment", 0)):
         segment = item.get("segment")
         prompt = item.get("prompt")
+        transition = item.get("transition", "continue")
+        start_prompt = item.get("start_prompt")
         
         if not segment or not prompt:
             logging.warning(f"Skipping invalid keyframe prompt item: {item}")
@@ -755,8 +773,40 @@ def generate_keyframes_from_json(json_file, output_dir, model_name=None, imageRo
         # The keyframe message is already shown in colored output
         
         try:
-            # Generate keyframe image
-            if prev_image_path:
+            if transition == "cut":
+                if not start_prompt:
+                    raise ValueError(f"Cut segment {segment} requires start_prompt")
+                start_path = os.path.join(output_dir, f"segment_{segment:02d}_start.png")
+                logging.info(f"Generating independent scene start: {start_path}")
+                generate_keyframe(
+                    prompt=start_prompt,
+                    output_path=start_path,
+                    model_name=model_name,
+                    imageRouter_api_key=imageRouter_api_key,
+                    stability_api_key=stability_api_key,
+                    openai_api_key=openai_api_key,
+                    gemini_api_key=gemini_api_key,
+                    input_image_path=None,
+                    size=image_size,
+                    create_mask=False,
+                    reference_images_dir=reference_images_dir,
+                    max_retries=max_retries,
+                )
+                generated_file = generate_keyframe(
+                    prompt=prompt,
+                    output_path=output_path,
+                    model_name=model_name,
+                    imageRouter_api_key=imageRouter_api_key,
+                    stability_api_key=stability_api_key,
+                    openai_api_key=openai_api_key,
+                    gemini_api_key=gemini_api_key,
+                    input_image_path=start_path,
+                    size=image_size,
+                    create_mask=False,
+                    reference_images_dir=reference_images_dir,
+                    max_retries=max_retries,
+                )
+            elif prev_image_path:
                 # Only keep one of the prev image messages
                 logging.info(f"Using previous keyframe as input: {prev_image_path}")
                 generated_file = generate_keyframe(
@@ -775,24 +825,8 @@ def generate_keyframes_from_json(json_file, output_dir, model_name=None, imageRo
                     max_retries=max_retries
                 )
             else:
-                # For first keyframe, use initial image if provided
-                initial_input = initial_image_path if segment == 1 and initial_image_path else None
-                if initial_input:
-                    logging.info(f"Using initial image as input for first keyframe: {initial_input}")
-                
-                generated_file = generate_keyframe(
-                    prompt=prompt,
-                    output_path=output_path,
-                    model_name=model_name,
-                    imageRouter_api_key=imageRouter_api_key,
-                    stability_api_key=stability_api_key,
-                    openai_api_key=openai_api_key,
-                    gemini_api_key=gemini_api_key,
-                    input_image_path=initial_input,
-                    size=image_size,
-                    create_mask=False,
-                    reference_images_dir=reference_images_dir,
-                    max_retries=max_retries
+                raise ValueError(
+                    f"Continue segment {segment} has no previous or initial frame"
                 )
             
             generated_files.append(generated_file)

--- a/keyframe_generator.py
+++ b/keyframe_generator.py
@@ -570,7 +570,7 @@ def generate_keyframe_with_gemini(
                                 image = ImageOps.fit(
                                     image,
                                     expected_size,
-                                    method=Image.Resampling.LANCZOS,
+                                    method=getattr(Image, "Resampling", Image).LANCZOS,
                                 )
                         if Path(output_path).suffix.lower() == ".png":
                             image.save(output_path, format="PNG")
@@ -823,6 +823,21 @@ def generate_keyframes_from_json(json_file, output_dir, model_name=None, imageRo
                     create_mask=False,
                     reference_images_dir=reference_images_dir,
                     max_retries=max_retries
+                )
+            elif segment == 1:
+                generated_file = generate_keyframe(
+                    prompt=prompt,
+                    output_path=output_path,
+                    model_name=model_name,
+                    imageRouter_api_key=imageRouter_api_key,
+                    stability_api_key=stability_api_key,
+                    openai_api_key=openai_api_key,
+                    gemini_api_key=gemini_api_key,
+                    input_image_path=None,
+                    size=image_size,
+                    create_mask=False,
+                    reference_images_dir=reference_images_dir,
+                    max_retries=max_retries,
                 )
             else:
                 raise ValueError(

--- a/pipeline.py
+++ b/pipeline.py
@@ -37,6 +37,7 @@ from generators.remote.fal_generator import (
     fal_profile_supports_last_frame,
     get_fal_clip_durations,
 )
+from generators.remote.minimax_generator import MinimaxGenerator
 from video_generator_interface import (
     APIError,
     GenerationTimeoutError,
@@ -203,6 +204,11 @@ def get_backend_clip_durations(config: Dict) -> tuple[int, ...] | None:
     """Return the active provider's allowed clip lengths, when constrained."""
     backend = _normalized_backend(get_video_generation_backend(config))
     if backend == "veo3":
+        if config.get("google_veo", {}).get("resolution", "720p") in {
+            "1080p",
+            "4k",
+        }:
+            return (8,)
         return VEO_CLIP_DURATIONS
     if backend == "fal":
         return get_fal_clip_durations(config.get("fal", {}).get("model"))
@@ -486,6 +492,37 @@ def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
         if video["last_frame"] != f"segment_{segment:02d}.png":
             raise ValueError(
                 f"Segment {segment} requires last_frame=segment_{segment:02d}.png"
+            )
+
+    backend = _normalized_backend(get_video_generation_backend(config))
+    if backend == "minimax":
+        max_duration = config.get("minimax", {}).get(
+            "max_duration", MinimaxGenerator.DEFAULT_MAX_DURATION
+        )
+        for item in video_prompts:
+            prompt = item.get("prompt")
+            if not isinstance(prompt, str) or not prompt.strip():
+                raise ValueError("LLM Minimax prompts cannot be empty")
+            if len(prompt) > MinimaxGenerator.MAX_PROMPT_LENGTH:
+                raise ValueError(
+                    "LLM Minimax prompts must be at most "
+                    f"{MinimaxGenerator.MAX_PROMPT_LENGTH} characters"
+                )
+            duration = item.get("duration_seconds")
+            if (
+                isinstance(duration, bool)
+                or not isinstance(duration, (int, float))
+                or duration < 1
+                or duration > max_duration
+            ):
+                raise ValueError(
+                    f"LLM Minimax durations must be between 1 and {max_duration} seconds"
+                )
+        total = sum(item["duration_seconds"] for item in video_prompts)
+        if segmentation.get("total_duration_seconds") != total:
+            raise ValueError(
+                f"LLM total duration {segmentation.get('total_duration_seconds')} "
+                f"does not match {total}"
             )
 
     durations_allowed = get_backend_clip_durations(config)

--- a/pipeline.py
+++ b/pipeline.py
@@ -28,6 +28,10 @@ from pydantic import BaseModel
 from api.config_merger import ConfigMerger
 from frame_extractor import extract_last_frame
 from generators.factory import create_video_generator, get_fallback_generator
+from generators.remote.fal_generator import (
+    fal_profile_supports_last_frame,
+    get_fal_clip_durations,
+)
 from video_generator_interface import (
     APIError,
     GenerationTimeoutError,
@@ -199,6 +203,25 @@ def get_video_generation_backend(config: Dict) -> str:
     return str(default_backend).lower()
 
 
+def _normalized_backend(backend: str) -> str:
+    name = str(backend).lower()
+    if name in {"fal", "fal.ai", "falgenerator"}:
+        return "fal"
+    if name in {"veo3", "veo3generator"}:
+        return "veo3"
+    return name
+
+
+def get_backend_clip_durations(config: Dict) -> tuple[int, ...] | None:
+    """Return the active provider's allowed clip lengths, when constrained."""
+    backend = _normalized_backend(get_video_generation_backend(config))
+    if backend == "veo3":
+        return VEO_CLIP_DURATIONS
+    if backend == "fal":
+        return get_fal_clip_durations(config.get("fal", {}).get("model"))
+    return None
+
+
 def get_provider_compatible_duration(
     config: Dict,
     primary_backend: str,
@@ -206,9 +229,9 @@ def get_provider_compatible_duration(
     planned_duration: float,
 ) -> float:
     """Map fallback attempts to the receiving provider's duration contract."""
-    if str(primary_backend).lower() == "veo3" and str(attempt_backend).lower() != "veo3":
-        return config.get("segment_duration_seconds", 5.0)
-    if str(attempt_backend).lower() == "veo3" and planned_duration not in VEO_CLIP_DURATIONS:
+    primary = _normalized_backend(primary_backend)
+    attempt = _normalized_backend(attempt_backend)
+    if attempt == "veo3" and planned_duration not in VEO_CLIP_DURATIONS:
         return next(
             (
                 duration
@@ -217,6 +240,15 @@ def get_provider_compatible_duration(
             ),
             VEO_CLIP_DURATIONS[-1],
         )
+    if attempt == "fal":
+        durations = get_fal_clip_durations(config.get("fal", {}).get("model"))
+        if planned_duration not in durations:
+            return next(
+                (duration for duration in durations if duration >= planned_duration),
+                durations[-1],
+            )
+    if primary in {"veo3", "fal"} and attempt not in {"veo3", "fal"}:
+        return config.get("segment_duration_seconds", 5.0)
     return planned_duration
 
 
@@ -258,6 +290,52 @@ def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
     return [8] * eights + [remainder]
 
 
+def plan_provider_segment_durations(
+    duration_seconds: int, allowed_durations: tuple[int, ...]
+) -> List[int]:
+    """Return a shortest exact provider plan, or the least-overrun plan."""
+    if allowed_durations == VEO_CLIP_DURATIONS:
+        return plan_veo_segment_durations(duration_seconds)
+    if (
+        isinstance(duration_seconds, bool)
+        or not isinstance(duration_seconds, int)
+        or duration_seconds <= 0
+    ):
+        raise ValueError("duration_seconds must be a positive integer")
+    if duration_seconds > MAX_REQUESTED_DURATION_SECONDS:
+        raise ValueError(
+            f"duration_seconds must be at most {MAX_REQUESTED_DURATION_SECONDS}"
+        )
+
+    limit = max(duration_seconds, allowed_durations[0]) + max(allowed_durations)
+    counts: list[int | None] = [None] * (limit + 1)
+    previous: list[tuple[int, int] | None] = [None] * (limit + 1)
+    counts[0] = 0
+    for total in range(limit + 1):
+        if counts[total] is None:
+            continue
+        for clip_duration in sorted(allowed_durations, reverse=True):
+            next_total = total + clip_duration
+            if next_total > limit:
+                continue
+            candidate_count = counts[total] + 1
+            if counts[next_total] is None or candidate_count < counts[next_total]:
+                counts[next_total] = candidate_count
+                previous[next_total] = (total, clip_duration)
+
+    for total in range(max(duration_seconds, min(allowed_durations)), limit + 1):
+        if counts[total] is not None:
+            plan = []
+            while total:
+                step = previous[total]
+                assert step is not None
+                predecessor, clip_duration = step
+                plan.append(clip_duration)
+                total = predecessor
+            return sorted(plan, reverse=True)
+    raise ValueError("No provider-compatible duration plan found")  # pragma: no cover
+
+
 def get_requested_segment_plan(config: Dict) -> Optional[List[int]]:
     """Build the current provider's segment plan when final duration is requested."""
     requested = config.get("duration_seconds")
@@ -277,13 +355,14 @@ def get_requested_segment_plan(config: Dict) -> Optional[List[int]]:
             "duration_seconds requires generation_mode=keyframe and "
             "single_keyframe_mode=true"
         )
-    if get_video_generation_backend(config) != "veo3":
-        raise ValueError("duration_seconds is currently supported only for the veo3 backend")
-    return plan_veo_segment_durations(int(requested))
+    durations = get_backend_clip_durations(config)
+    if durations is None:
+        raise ValueError("duration_seconds is currently supported only for veo3 and fal backends")
+    return plan_provider_segment_durations(int(requested), durations)
 
 
 def get_requested_job_timeout(config: Dict) -> int:
-    """Allow enough queue time for every planned Veo request plus pipeline overhead."""
+    """Allow enough queue time for every planned provider request plus pipeline overhead."""
     plan = get_requested_segment_plan(config)
     if not plan:
         return 3600
@@ -298,9 +377,19 @@ def get_duration_tradeoff(config: Dict) -> Optional[str]:
     plan = get_requested_segment_plan(config)
     requested = config.get("duration_seconds")
     if plan and sum(plan) > requested:
+        backend = _normalized_backend(get_video_generation_backend(config))
+        durations = get_backend_clip_durations(config)
+        has_last_frame = backend == "veo3" or fal_profile_supports_last_frame(
+            config.get("fal", {}).get("model")
+        )
+        ending = (
+            "the final clip's ending keyframe will not appear"
+            if has_last_frame
+            else "the final generated endpoint will be removed"
+        )
         return (
-            f"Requested {requested}s cannot be composed exactly from Veo clips {list(VEO_CLIP_DURATIONS)}; "
-            f"the {sum(plan)}s plan will be trimmed, so the final clip's ending keyframe will not appear."
+            f"Requested {requested}s cannot be composed exactly from {backend} clips {list(durations)}; "
+            f"the {sum(plan)}s plan will be trimmed, so {ending}."
         )
     return None
 
@@ -312,15 +401,19 @@ def get_trim_duration_seconds(config: Dict) -> Optional[int]:
 
 def build_prompt_enhancement_instructions(config: Dict) -> str:
     """Add only the active backend's prompt and duration constraints."""
-    backend = get_video_generation_backend(config)
+    backend = _normalized_backend(get_video_generation_backend(config))
     instructions = PROMPT_ENHANCEMENT_INSTRUCTIONS
     if backend == "minimax":
         instructions += "\n\nIMPORTANT: Each Minimax video prompt must be 500 characters or less."
-    elif backend == "veo3":
+    elif backend in {"veo3", "fal"}:
+        clip_durations = get_backend_clip_durations(config)
+        example_duration = min(clip_durations)
         instructions = instructions.replace(
-            '"total_duration_seconds": 10', '"total_duration_seconds": 8'
-        ).replace('"duration_seconds": 5', '"duration_seconds": 4')
-        instructions += "\n\nIMPORTANT: Each Veo video prompt must be 1000 characters or less."
+            '"total_duration_seconds": 10',
+            f'"total_duration_seconds": {example_duration * 2}',
+        ).replace('"duration_seconds": 5', f'"duration_seconds": {example_duration}')
+        if backend == "veo3":
+            instructions += "\n\nIMPORTANT: Each Veo video prompt must be 1000 characters or less."
         plan = get_requested_segment_plan(config)
         if plan:
             requested = int(config["duration_seconds"])
@@ -335,7 +428,7 @@ def build_prompt_enhancement_instructions(config: Dict) -> str:
         else:
             instructions += (
                 f"\nInfer the final runtime and segment count. Every video_prompt must include duration_seconds "
-                f"as one of {list(VEO_CLIP_DURATIONS)}, and segmentation_logic.total_duration_seconds must equal "
+                f"as one of {list(clip_durations)}, and segmentation_logic.total_duration_seconds must equal "
                 "the sum of those durations."
             )
     return instructions
@@ -343,7 +436,8 @@ def build_prompt_enhancement_instructions(config: Dict) -> str:
 
 def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
     """Reject an LLM decomposition that does not match the provider duration plan."""
-    if get_video_generation_backend(config) != "veo3":
+    durations_allowed = get_backend_clip_durations(config)
+    if durations_allowed is None:
         return
 
     video_prompts = result["video_prompts"]
@@ -363,11 +457,11 @@ def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
         not item.get("first_frame") or not item.get("last_frame")
         for item in video_prompts
     ):
-        raise ValueError("LLM Veo segments must include first_frame and last_frame")
+        raise ValueError("LLM provider segments must include first_frame and last_frame")
     if expected and durations != expected:
         raise ValueError(f"LLM durations {durations} do not match requested segment plan {expected}")
-    if not expected and any(duration not in VEO_CLIP_DURATIONS for duration in durations):
-        raise ValueError(f"LLM durations must use Veo values {list(VEO_CLIP_DURATIONS)}")
+    if not expected and any(duration not in durations_allowed for duration in durations):
+        raise ValueError(f"LLM durations must use provider values {list(durations_allowed)}")
 
     expected_total = int(config["duration_seconds"]) if expected else sum(durations)
     if segmentation.get("total_duration_seconds") != expected_total:
@@ -999,7 +1093,7 @@ def generate_video_segments_single_keyframe(
         )
 
         # Veo first/last-frame generation always starts from the first frame.
-        if backend == 'veo3':
+        if backend in {'veo3', 'fal', 'fal.ai'}:
             keyframe_path = prompt_item.get('first_frame')
         elif keyframe_position == 'first' and 'first_frame' in prompt_item:
             keyframe_path = prompt_item['first_frame']

--- a/pipeline.py
+++ b/pipeline.py
@@ -777,7 +777,6 @@ def prepare_keyframes(
             frame_path = resolve_frame_reference(frame_ref, frames_dir)
             if not os.path.exists(frame_path):
                 raise FileNotFoundError(f"{field} not found: {frame_path}")
-            prompt_item[field] = frame_path
 
     if generated_initial and os.path.exists(generated_initial):
         os.remove(generated_initial)
@@ -851,10 +850,8 @@ def generate_single_video_segment(
         logging.info(f"Segment {seg} using GPUs: {gpu_ids}")
         print(f"{Colors.BOLD}{Colors.YELLOW}Segment {seg}{Colors.RESET} using GPUs: {Colors.CYAN}{gpu_ids}{Colors.RESET}")
 
-    # ALWAYS use this exact directory structure - no exceptions
-    base_dir = os.getcwd()
-    frames_dir = os.path.join(base_dir, "output", "frames")
-    videos_dir = os.path.join(base_dir, "output", "videos")
+    frames_dir = os.path.join(output_dir, "frames")
+    videos_dir = os.path.join(output_dir, "videos")
 
     # Create fresh directories if needed (safe in multiprocessing)
     os.makedirs(frames_dir, exist_ok=True)
@@ -864,8 +861,10 @@ def generate_single_video_segment(
     print(f"\n{Colors.BOLD}{Colors.YELLOW}Generating video for segment {seg}:{Colors.RESET}")
     print(f"{Colors.CYAN}{prompt_text[:100]}...{Colors.RESET}")
 
+    if prompt_item.get("first_frame"):
+        first_file = resolve_frame_reference(prompt_item["first_frame"], frames_dir)
     # For the first segment, use the initial_image if provided
-    if seg == 1 and config.get("initial_image"):
+    elif seg == 1 and config.get("initial_image"):
         initial_image = config.get("initial_image")
         # Always use absolute paths for consistency
         if not os.path.isabs(initial_image):
@@ -889,7 +888,9 @@ def generate_single_video_segment(
             raise FileNotFoundError(f"Previous frame not found: {first_file}")
 
     # Path for this segment's keyframe
-    last_file = os.path.join(frames_dir, f"segment_{seg:02d}.png")
+    last_file = resolve_frame_reference(prompt_item.get("last_frame"), frames_dir)
+    if not last_file:
+        last_file = os.path.join(frames_dir, f"segment_{seg:02d}.png")
     if not os.path.exists(last_file):
         logging.error(f"Keyframe not found: {last_file}")
         logging.error(f"Directory contents: {os.listdir(frames_dir)}")
@@ -1241,8 +1242,10 @@ def generate_video_segments_sequential(
     for item in video_prompts:
         seg, prompt_text = item["segment"], item["prompt"]
 
-        # Determine the first frame for this segment
-        if seg == 1:
+        # Prefer the reviewed plan's explicit frame, especially across cuts.
+        if item.get("first_frame"):
+            first_file = resolve_frame_reference(item["first_frame"], frames_dir)
+        elif seg == 1:
             # For the first segment, check if initial_image is provided
             if config.get("initial_image"):
                 initial_image = config.get("initial_image")
@@ -1272,7 +1275,9 @@ def generate_video_segments_sequential(
                 raise FileNotFoundError(f"Previous frame not found: {first_file}")
 
         # Path for this segment's keyframe
-        last_file = os.path.join(frames_dir, f"segment_{seg:02d}.png")
+        last_file = resolve_frame_reference(item.get("last_frame"), frames_dir)
+        if not last_file:
+            last_file = os.path.join(frames_dir, f"segment_{seg:02d}.png")
         if not os.path.exists(last_file):
             logging.error(f"Keyframe not found: {last_file}")
             logging.error(f"Directory contents: {os.listdir(frames_dir)}")

--- a/pipeline.py
+++ b/pipeline.py
@@ -582,7 +582,6 @@ def enhance_prompt_data(prompt: str, config: Dict) -> Dict:
             batch_result = enhancer.enhance(
                 build_prompt_enhancement_instructions(batch_config), batch_prompt
             )
-            validate_prompt_enhancement(batch_result, batch_config)
             reasonings.append(batch_result["segmentation_logic"]["reasoning"])
 
             for local_index, (keyframe_prompt, video_prompt) in enumerate(
@@ -1101,7 +1100,8 @@ def process_segment(prompt_item, gpu_ids, wan2_dir, config, output_dir, flf2v_mo
 def generate_video_segments_single_keyframe(
     config: Dict,
     video_prompts: List[Dict],
-    output_dir: str
+    output_dir: str,
+    cancellation_check=None,
 ) -> List[str]:
     """
     Generate video segments through remote keyframe APIs (e.g., Veo3 first/last frame).
@@ -1138,6 +1138,8 @@ def generate_video_segments_single_keyframe(
     logging.info(f"Absolute frames directory path for single-keyframe mode: {frames_dir_abs}")
 
     for prompt_item in video_prompts:
+        if cancellation_check and cancellation_check():
+            raise InterruptedError("Video generation cancelled")
         seg, prompt_text = prompt_item["segment"], prompt_item["prompt"]
         segment_duration = prompt_item.get(
             "duration_seconds", config.get("segment_duration_seconds", 5.0)
@@ -1192,6 +1194,7 @@ def generate_video_segments_single_keyframe(
                 output_path=video_file,
                 duration=segment_duration,
                 last_frame_path=last_frame_path,
+                cancellation_check=cancellation_check,
             )
 
             video_paths.append(video_file)
@@ -1219,6 +1222,7 @@ def generate_video_segments_single_keyframe(
                     output_path=video_file,
                     duration=fallback_duration,
                     last_frame_path=last_frame_path,
+                    cancellation_check=cancellation_check,
                 )
                 video_paths.append(video_file)
                 logging.info(f"Fallback succeeded for segment {seg}")

--- a/pipeline.py
+++ b/pipeline.py
@@ -200,16 +200,20 @@ def _normalized_backend(backend: str) -> str:
     return name
 
 
+def _get_veo_clip_durations(config: Dict) -> tuple[int, ...]:
+    if config.get("google_veo", {}).get("resolution", "720p") in {
+        "1080p",
+        "4k",
+    }:
+        return (8,)
+    return VEO_CLIP_DURATIONS
+
+
 def get_backend_clip_durations(config: Dict) -> tuple[int, ...] | None:
     """Return the active provider's allowed clip lengths, when constrained."""
     backend = _normalized_backend(get_video_generation_backend(config))
     if backend == "veo3":
-        if config.get("google_veo", {}).get("resolution", "720p") in {
-            "1080p",
-            "4k",
-        }:
-            return (8,)
-        return VEO_CLIP_DURATIONS
+        return _get_veo_clip_durations(config)
     if backend == "fal":
         return get_fal_clip_durations(config.get("fal", {}).get("model"))
     return None
@@ -224,15 +228,13 @@ def get_provider_compatible_duration(
     """Map fallback attempts to the receiving provider's duration contract."""
     primary = _normalized_backend(primary_backend)
     attempt = _normalized_backend(attempt_backend)
-    if attempt == "veo3" and planned_duration not in VEO_CLIP_DURATIONS:
-        return next(
-            (
-                duration
-                for duration in VEO_CLIP_DURATIONS
-                if duration >= planned_duration
-            ),
-            VEO_CLIP_DURATIONS[-1],
-        )
+    if attempt == "veo3":
+        durations = _get_veo_clip_durations(config)
+        if planned_duration not in durations:
+            return next(
+                (duration for duration in durations if duration >= planned_duration),
+                durations[-1],
+            )
     if attempt == "fal":
         durations = get_fal_clip_durations(config.get("fal", {}).get("model"))
         if planned_duration not in durations:
@@ -243,6 +245,25 @@ def get_provider_compatible_duration(
     if primary in {"veo3", "fal"} and attempt not in {"veo3", "fal"}:
         return config.get("segment_duration_seconds", 5.0)
     return planned_duration
+
+
+def apply_reviewed_plan_config(
+    config: Dict, reviewed_plan: Dict, duration_seconds: Optional[int]
+) -> None:
+    """Attach a reviewed plan without retaining an unrelated configured duration."""
+    if duration_seconds is None:
+        requested_total = reviewed_plan["segmentation_logic"][
+            "total_duration_seconds"
+        ]
+        generated_total = sum(
+            segment["duration_seconds"]
+            for segment in reviewed_plan["video_prompts"]
+        )
+        if requested_total != generated_total:
+            config["duration_seconds"] = requested_total
+        else:
+            config.pop("duration_seconds", None)
+    config["enhanced_prompt"] = reviewed_plan
 
 
 def resolve_frame_reference(frame_ref: Optional[str], frames_dir: str) -> Optional[str]:
@@ -1733,7 +1754,7 @@ def run_pipeline(
 
     if enhanced_prompt_file:
         with open(enhanced_prompt_file, "r") as file:
-            config["enhanced_prompt"] = json.load(file)
+            apply_reviewed_plan_config(config, json.load(file), duration_seconds)
 
     # Reject unsupported or excessive requests before any generation work.
     get_requested_segment_plan(config)

--- a/pipeline.py
+++ b/pipeline.py
@@ -378,6 +378,8 @@ def get_requested_job_timeout(config: Dict) -> int:
     """Allow enough queue time for every planned provider request plus pipeline overhead."""
     plan = get_requested_segment_plan(config)
     if not plan:
+        plan = (config.get("enhanced_prompt") or {}).get("video_prompts", [])
+    if not plan:
         return 3600
     provider_timeout = max(
         600, int(config.get("remote_api_settings", {}).get("timeout", 600))

--- a/pipeline.py
+++ b/pipeline.py
@@ -449,16 +449,10 @@ def build_prompt_enhancement_instructions(config: Dict) -> str:
 
 def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
     """Reject an LLM decomposition that does not match the provider duration plan."""
-    durations_allowed = get_backend_clip_durations(config)
-    if durations_allowed is None:
-        return
-
     video_prompts = result["video_prompts"]
     keyframe_prompts = result["keyframe_prompts"]
     segmentation = result["segmentation_logic"]
     segment_numbers = list(range(1, len(video_prompts) + 1))
-    durations = [item.get("duration_seconds") for item in video_prompts]
-    expected = get_requested_segment_plan(config)
 
     if [item.get("segment") for item in video_prompts] != segment_numbers:
         raise ValueError("LLM video segments are not sequential")
@@ -491,6 +485,13 @@ def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
             raise ValueError(
                 f"Segment {segment} requires last_frame=segment_{segment:02d}.png"
             )
+
+    durations_allowed = get_backend_clip_durations(config)
+    if durations_allowed is None:
+        return
+
+    durations = [item.get("duration_seconds") for item in video_prompts]
+    expected = get_requested_segment_plan(config)
     if expected and durations != expected:
         raise ValueError(f"LLM durations {durations} do not match requested segment plan {expected}")
     if not expected and any(duration not in durations_allowed for duration in durations):

--- a/pipeline.py
+++ b/pipeline.py
@@ -1706,7 +1706,14 @@ def run_pipeline(
     # Call the enhanced prompt function with colorful output
     enhanced_data = enhance_prompt(raw_prompt or "Reviewed prompt plan", config, output_dir)
     if plan_only:
-        return os.path.join(output_dir, "enhanced_prompt.json")
+        if not enhanced_data.get("video_prompts"):
+            raise ValueError(
+                "--plan-only requires an OpenAI API key or --enhanced-prompt-file"
+            )
+        plan_path = os.path.join(output_dir, "enhanced_prompt.json")
+        if not os.path.isfile(plan_path):
+            raise RuntimeError(f"Plan was not written: {plan_path}")
+        return plan_path
 
     frames_dir = os.path.join(output_dir, "frames")
     videos_dir = os.path.join(output_dir, "videos")

--- a/pipeline.py
+++ b/pipeline.py
@@ -23,9 +23,14 @@ from typing import Dict, List, Optional, Union
 
 import yaml
 from instructor import from_openai, Mode
-from pydantic import BaseModel
 
 from api.config_merger import ConfigMerger
+from api.models import (
+    KeyframePrompt,  # noqa: F401 - kept as a public pipeline import
+    PromptEnhancementResult,
+    SegmentationLogic,  # noqa: F401 - kept as a public pipeline import
+    VideoPrompt,  # noqa: F401 - kept as a public pipeline import
+)
 from frame_extractor import extract_last_frame
 from generators.factory import create_video_generator, get_fallback_generator
 from generators.remote.fal_generator import (
@@ -68,31 +73,6 @@ logging.basicConfig(
     format="[%(asctime)s] %(levelname)s: %(message)s"
 )
 
-# ============================================================================
-# Pydantic Models for Structured Prompt Enhancement
-# ============================================================================
-
-class SegmentationLogic(BaseModel):
-    total_duration_seconds: int
-    number_of_segments: int
-    reasoning: str
-
-class KeyframePrompt(BaseModel):
-    segment: int
-    prompt: str
-
-class VideoPrompt(BaseModel):
-    segment: int
-    prompt: str
-    first_frame: Optional[str] = None
-    last_frame: Optional[str] = None
-    duration_seconds: int
-
-class PromptEnhancementResult(BaseModel):
-    segmentation_logic: SegmentationLogic
-    keyframe_prompts: List[KeyframePrompt]
-    video_prompts: List[VideoPrompt]
-
 # Instructions for prompt splitting and enhancement
 PROMPT_ENHANCEMENT_INSTRUCTIONS = """
 Split and enhance an input text-to-video prompt and starting reference image into detailed, standalone prompts for video segments. This requires narrative pacing, descriptive clarity, cinematic knowledge, and continuity skills.
@@ -100,7 +80,7 @@ Split and enhance an input text-to-video prompt and starting reference image int
 Analyze the Input Prompt and Starting Reference Image
 - Prompt Analysis: Identify the setting, characters, actions, camera movements, and style (e.g., mood, lighting).
 - Image Analysis: Examine the starting reference image (`provided_start_image.png`) for visual context, such as character positions or environmental details.
-- Continuity: Ensure each prompt is standalone, with full descriptions (e.g., "A woman in a red dress, tall and athletic") and uses reference images to link segments visually.
+- Continuity: Mark each segment as `cut` when it starts a new scene, era, location, or subject. Use `continue` only when the next segment is another shot in the same scene.
 
 Determine Duration and Segmentation
 - Estimate the total duration based on the complexity and pacing of actions.
@@ -121,22 +101,26 @@ Prompting Guidelines: Effective Prompting Techniques
 
 Generate Keyframe Prompts
 - Write text-to-image prompts for the last frame of each segment.
+- Set `transition` to `cut` or `continue`.
+- For `cut`, also write `start_prompt` for an independent first frame in the new scene. The end frame will be generated from that start frame so subjects cannot leak across scene boundaries.
+- For `continue`, omit `start_prompt`; the preceding segment's end frame is reused as the start.
 - Focus on the static scene: characters, objects, setting, and style.
 - Note that each segment is prompted separate, with no knowledge of prior segments other than the reference image. Therefore, if you refer to characters by name, be sure to explain who they are in the prompt.
 - Exclude camera movement; emphasize visual composition.
-- Each keyframe prompt generates an image (e.g., `segment_01.png`) that becomes the last frame of its segment and the first frame of the next segment.
+- Each keyframe prompt generates an end image such as `segment_01.png`. A `cut` also generates `segment_01_start.png`.
 
 Generate Video Prompts
 - Write one text-to-video prompt for each segment.
 - Detail actions, camera movements, and style.
 - Include `duration_seconds` for every video prompt; use 5 unless backend-specific requirements say otherwise.
-- Reference the first frame (`provided_start_image.png` for segment 1, `segment_XX.png` for others) and last frame (`segment_YY.png`).
+- For `cut`, reference `segment_YY_start.png` as first_frame and `segment_YY.png` as last_frame.
+- For `continue`, reference the preceding `segment_XX.png` as first_frame and the current `segment_YY.png` as last_frame. Segment 1 may use `provided_start_image.png` only when it truly continues a supplied image.
 - Ensure each prompt is standalone with full context.
 
 Reference Image Naming
-- The starting image is `provided_start_image.png` (used as the first frame of segment 1).
-- Each segment's last frame is named sequentially (e.g., `segment_01.png`, `segment_02.png`).
-- The last frame of one segment (e.g., `segment_01.png`) becomes the first frame of the next segment, ensuring visual continuity.
+- A cut segment N uses `segment_NN_start.png` and `segment_NN.png`.
+- A continuing segment N uses `segment_(NN-1).png` and `segment_NN.png`.
+- Do not carry a previous character, vehicle, architecture, or landscape across a cut.
 
 Output Format
 - Use JSON with:
@@ -157,10 +141,13 @@ Expected Output (JSON):
   "keyframe_prompts": [
     {
       "segment": 1,
+      "transition": "cut",
+      "start_prompt": "A woman in a red dress poised at the curb of a rainy street at night, cinematic lighting, viewed from behind.",
       "prompt": "A woman in a red dress, mid-stride, running on a rainy street at night, cinematic lighting, viewed from behind, streetlights reflecting on wet pavement."
     },
     {
       "segment": 2,
+      "transition": "continue",
       "prompt": "A woman in a red dress, reaching the other side of a rainy street at night, cinematic lighting, viewed from behind, streetlights reflecting on wet pavement."
     }
   ],
@@ -168,7 +155,7 @@ Expected Output (JSON):
     {
       "segment": 1,
       "prompt": "The camera tracks behind a woman in a red dress as she begins running across a rainy street at night, cinematic lighting, streetlights reflecting on wet pavement, rendered in a realistic style.",
-      "first_frame": "provided_start_image.png",
+      "first_frame": "segment_01_start.png",
       "last_frame": "segment_01.png",
       "duration_seconds": 5
     },
@@ -266,6 +253,32 @@ def resolve_frame_reference(frame_ref: Optional[str], frames_dir: str) -> Option
     if os.path.commonpath((frames_dir, frame_path)) != frames_dir:
         raise ValueError(f"Invalid frame path: {frame_ref}")
     return frame_path
+
+
+def validate_existing_keyframes(video_prompts: List[Dict], output_dir: str) -> None:
+    """Fail before video submission when a reviewed storyboard is incomplete."""
+    from PIL import Image
+
+    frames_dir = os.path.join(output_dir, "frames")
+    for prompt_item in video_prompts:
+        resolved_paths = {}
+        for field in ("first_frame", "last_frame"):
+            frame_path = resolve_frame_reference(prompt_item.get(field), frames_dir)
+            if not frame_path or not os.path.exists(frame_path):
+                raise FileNotFoundError(
+                    f"Segment {prompt_item.get('segment')} {field} not found: {frame_path}"
+                )
+            with Image.open(frame_path) as image:
+                image.load()
+                resolved_paths[field] = (frame_path, image.size)
+
+        first_path, first_size = resolved_paths["first_frame"]
+        last_path, last_size = resolved_paths["last_frame"]
+        if first_size != last_size:
+            raise ValueError(
+                f"Segment {prompt_item.get('segment')} keyframe dimensions do not match: "
+                f"{first_path} is {first_size}, {last_path} is {last_size}"
+            )
 
 
 def plan_veo_segment_durations(duration_seconds: int) -> List[int]:
@@ -458,6 +471,26 @@ def validate_prompt_enhancement(result: Dict, config: Dict) -> None:
         for item in video_prompts
     ):
         raise ValueError("LLM provider segments must include first_frame and last_frame")
+    for keyframe, video in zip(keyframe_prompts, video_prompts, strict=True):
+        segment = video["segment"]
+        transition = keyframe.get("transition", "continue")
+        expected_first = (
+            f"segment_{segment:02d}_start.png"
+            if transition == "cut"
+            else (
+                "provided_start_image.png"
+                if segment == 1
+                else f"segment_{segment - 1:02d}.png"
+            )
+        )
+        if video["first_frame"] != expected_first:
+            raise ValueError(
+                f"Segment {segment} {transition} transition requires first_frame={expected_first}"
+            )
+        if video["last_frame"] != f"segment_{segment:02d}.png":
+            raise ValueError(
+                f"Segment {segment} requires last_frame=segment_{segment:02d}.png"
+            )
     if expected and durations != expected:
         raise ValueError(f"LLM durations {durations} do not match requested segment plan {expected}")
     if not expected and any(duration not in durations_allowed for duration in durations):
@@ -501,6 +534,13 @@ class PromptEnhancer:
 
 def enhance_prompt_data(prompt: str, config: Dict) -> Dict:
     """Enhance and validate a prompt using the effective pipeline configuration."""
+    if config.get("enhanced_prompt") is not None:
+        result = PromptEnhancementResult.model_validate(
+            config["enhanced_prompt"]
+        ).model_dump(exclude_unset=True)
+        validate_prompt_enhancement(result, config)
+        return result
+
     enhancer = PromptEnhancer(
         api_key=config.get("openai_api_key"),
         base_url=config.get("openai_base_url", "https://api.openai.com/v1"),
@@ -552,13 +592,18 @@ def enhance_prompt_data(prompt: str, config: Dict) -> Dict:
             ):
                 segment = offset + local_index
                 keyframe_prompt = {**keyframe_prompt, "segment": segment}
+                transition = keyframe_prompt.get("transition", "continue")
                 video_prompt = {
                     **video_prompt,
                     "segment": segment,
                     "first_frame": (
-                        "provided_start_image.png"
-                        if segment == 1
-                        else f"segment_{segment - 1:02d}.png"
+                        f"segment_{segment:02d}_start.png"
+                        if transition == "cut"
+                        else (
+                            "provided_start_image.png"
+                            if segment == 1
+                            else f"segment_{segment - 1:02d}.png"
+                        )
                     ),
                     "last_frame": f"segment_{segment:02d}.png",
                 }
@@ -667,16 +712,21 @@ def prepare_keyframes(
     model_name = config.get("image_generation_model")
     if not model_name:
         raise ValueError("No image generation model specified")
+    if not keyframe_prompts:
+        raise ValueError("No keyframe prompts were generated")
 
-    initial_image = config.get("initial_image")
+    first_transition = (
+        keyframe_prompts[0].get("transition", "continue")
+        if keyframe_prompts and isinstance(keyframe_prompts[0], dict)
+        else "continue"
+    )
+    initial_image = config.get("initial_image") if first_transition != "cut" else None
     generated_initial = None
     if initial_image:
         initial_image = os.path.abspath(initial_image)
         if not os.path.exists(initial_image):
             raise FileNotFoundError(f"Initial image not found: {initial_image}")
-    else:
-        if not keyframe_prompts:
-            raise ValueError("No keyframe prompts were generated")
+    elif first_transition != "cut":
         first_prompt = keyframe_prompts[0]
         if isinstance(first_prompt, dict):
             first_prompt = first_prompt["prompt"]
@@ -716,7 +766,7 @@ def prepare_keyframes(
 
     frames_dir = os.path.abspath(os.path.join(output_dir, "frames"))
     segment_00_path = os.path.join(frames_dir, "segment_00.png")
-    if os.path.abspath(initial_image) != segment_00_path:
+    if initial_image and os.path.abspath(initial_image) != segment_00_path:
         shutil.copy2(initial_image, segment_00_path)
 
     for prompt_item in video_prompts:
@@ -1112,8 +1162,20 @@ def generate_video_segments_single_keyframe(
             logging.error(f"No keyframe found for segment {seg}")
             continue
 
+        if last_frame_path:
+            from PIL import Image
+
+            with Image.open(keyframe_path) as first_image, Image.open(
+                last_frame_path
+            ) as last_image:
+                if first_image.size != last_image.size:
+                    raise InvalidInputError(
+                        f"Segment {seg} first/last keyframe dimensions do not match: "
+                        f"{first_image.size} != {last_image.size}"
+                    )
+
         logging.info(f"Generating video for segment {seg} using keyframe: {keyframe_path}")
-        video_file = os.path.join(output_dir, f"segment_{seg:03d}.mp4")
+        video_file = os.path.join(videos_dir, f"segment_{seg:03d}.mp4")
 
         try:
             # Create video generator
@@ -1301,7 +1363,7 @@ def enhance_prompt(prompt: str, config: Dict, output_dir: str) -> Dict:
 
     logging.info("Enhancing input prompt...")
 
-    if not config.get("openai_api_key"):
+    if not config.get("openai_api_key") and config.get("enhanced_prompt") is None:
         logging.warning("No OpenAI API key provided, skipping prompt enhancement")
         return {"keyframe_prompts": [], "video_prompts": []}
 
@@ -1586,8 +1648,18 @@ def run_pipeline(
     config_path: str,
     prompt_override: str = None,
     duration_seconds: Optional[int] = None,
+    plan_only: bool = False,
+    enhanced_prompt_file: Optional[str] = None,
+    keyframes_only: bool = False,
+    reuse_keyframes: bool = False,
 ) -> None:
     """Run the end-to-end pipeline using configuration from YAML"""
+    if plan_only and (keyframes_only or reuse_keyframes):
+        raise ValueError("--plan-only cannot be combined with keyframe generation options")
+    if keyframes_only and reuse_keyframes:
+        raise ValueError("--keyframes-only cannot be combined with --reuse-keyframes")
+    if reuse_keyframes and not enhanced_prompt_file:
+        raise ValueError("--reuse-keyframes requires --enhanced-prompt-file")
     logging.info(f"Loading configuration from {config_path}")
     base_config = load_config(config_path)
 
@@ -1605,37 +1677,45 @@ def run_pipeline(
         http_overrides=None  # No HTTP overrides in CLI context
     )
 
+    if (keyframes_only or reuse_keyframes) and config.get(
+        "generation_mode", "keyframe"
+    ).lower() != "keyframe":
+        raise ValueError("Keyframe checkpoints require generation_mode=keyframe")
+
+    if enhanced_prompt_file:
+        with open(enhanced_prompt_file, "r") as file:
+            config["enhanced_prompt"] = json.load(file)
+
     # Reject unsupported or excessive requests before any generation work.
     get_requested_segment_plan(config)
 
     base_dir = os.getcwd()  # Current working directory
     output_dir = os.path.join(base_dir, "output")
-    frames_dir = os.path.join(output_dir, "frames")
-    videos_dir = os.path.join(output_dir, "videos")
-
-    # Delete and recreate directories to ensure no nested subdirs
-    import shutil
-    if os.path.exists(frames_dir):
-        shutil.rmtree(frames_dir)
-    if os.path.exists(videos_dir):
-        shutil.rmtree(videos_dir)
-
-    # Create clean directories
     os.makedirs(output_dir, exist_ok=True)
-    os.makedirs(frames_dir, exist_ok=True)
-    os.makedirs(videos_dir, exist_ok=True)
-
-    # Log directory structure
-    logging.info(f"Frames directory: {frames_dir}")
-    logging.info(f"Videos directory: {videos_dir}")
 
     # Step 1: Enhance the input prompt
     raw_prompt = config.get("prompt")
-    if not raw_prompt:
+    if not raw_prompt and not enhanced_prompt_file:
         raise ValueError("No prompt provided in configuration or command line")
 
     # Call the enhanced prompt function with colorful output
-    enhanced_data = enhance_prompt(raw_prompt, config, output_dir)
+    enhanced_data = enhance_prompt(raw_prompt or "Reviewed prompt plan", config, output_dir)
+    if plan_only:
+        return os.path.join(output_dir, "enhanced_prompt.json")
+
+    frames_dir = os.path.join(output_dir, "frames")
+    videos_dir = os.path.join(output_dir, "videos")
+
+    # Delete and recreate directories only after the plan is approved.
+    if os.path.exists(frames_dir) and not reuse_keyframes:
+        shutil.rmtree(frames_dir)
+    if os.path.exists(videos_dir):
+        shutil.rmtree(videos_dir)
+    os.makedirs(frames_dir, exist_ok=True)
+    os.makedirs(videos_dir, exist_ok=True)
+
+    logging.info(f"Frames directory: {frames_dir}")
+    logging.info(f"Videos directory: {videos_dir}")
 
     # Determine which generation mode we're using
     generation_mode = config.get('generation_mode', 'keyframe').lower()
@@ -1649,12 +1729,20 @@ def run_pipeline(
         logging.info(f"Starting keyframe generation for {len(enhanced_data['keyframe_prompts'])} segments")
         print(f"\n{Colors.BOLD}{Colors.PURPLE}Generating Keyframes:{Colors.RESET}")
 
-        prepare_keyframes(
-            config,
-            keyframe_prompts=enhanced_data['keyframe_prompts'],
-            video_prompts=enhanced_data['video_prompts'],
-            output_dir=output_dir,
-        )
+        if reuse_keyframes:
+            validate_existing_keyframes(enhanced_data['video_prompts'], output_dir)
+            logging.info("Using reviewed keyframes from the existing output/frames directory")
+        else:
+            prepare_keyframes(
+                config,
+                keyframe_prompts=enhanced_data['keyframe_prompts'],
+                video_prompts=enhanced_data['video_prompts'],
+                output_dir=output_dir,
+            )
+
+        if keyframes_only:
+            logging.info(f"Keyframe checkpoint complete: {frames_dir}")
+            return frames_dir
 
         # Get FLF2V model directory for keyframe mode
         flf2v_model_dir = config.get('flf2v_model_dir', './Wan2.1-FLF2V-14B-720P')
@@ -1756,9 +1844,36 @@ def main():
             f'(Veo 3 only; max {MAX_REQUESTED_DURATION_SECONDS})'
         ),
     )
+    parser.add_argument(
+        '--plan-only',
+        action='store_true',
+        help='Write output/enhanced_prompt.json and stop before media generation',
+    )
+    parser.add_argument(
+        '--enhanced-prompt-file',
+        help='Use a reviewed enhanced prompt JSON file instead of decomposing again',
+    )
+    parser.add_argument(
+        '--keyframes-only',
+        action='store_true',
+        help='Generate output/frames and stop before video generation',
+    )
+    parser.add_argument(
+        '--reuse-keyframes',
+        action='store_true',
+        help='Generate video from reviewed keyframes already in output/frames',
+    )
 
     args = parser.parse_args()
-    run_pipeline(args.config, args.prompt, args.duration_seconds)
+    run_pipeline(
+        args.config,
+        args.prompt,
+        args.duration_seconds,
+        args.plan_only,
+        args.enhanced_prompt_file,
+        args.keyframes_only,
+        args.reuse_keyframes,
+    )
 
 if __name__ == "__main__":
     main()

--- a/pipeline_config.yaml.sample
+++ b/pipeline_config.yaml.sample
@@ -91,15 +91,28 @@ minimax:
 
 # Remote API configuration - fal.ai
 fal:
-  api_key: "YOUR_FAL_API_KEY"                 # Required unless FAL_API_KEY env var is set
-  model: "fal-ai/minimax/hailuo-02/standard/image-to-video"  # Any fal model endpoint ID
-  base_url: "https://fal.run"                 # fal synchronous endpoint base URL
-  max_duration: 10                             # Per-request duration cap enforced by this pipeline
-  default_input: {}                            # Optional model-specific default input fields
+  api_key: "YOUR_FAL_KEY"                     # Required unless FAL_KEY is set; FAL_API_KEY remains a compatibility fallback
+  model: "bytedance/seedance-2.0/image-to-video"
+  base_url: "https://queue.fal.run"
+  queue_start_timeout: 300                     # Maximum queue wait before fal starts processing
+  default_input:                               # Only documented fields for the selected profile are accepted
+    resolution: "720p"
+    aspect_ratio: "16:9"
+# Supported profiles:
+# - bytedance/seedance-2.0/image-to-video
+# - bytedance/seedance-2.0/fast/image-to-video
+# - fal-ai/veo3.1/image-to-video
+# - fal-ai/veo3.1/first-last-frame-to-video
+# - fal-ai/veo3.1/fast/image-to-video
+# - fal-ai/veo3.1/fast/first-last-frame-to-video
+# - fal-ai/minimax/hailuo-02/standard/image-to-video
+# - fal-ai/minimax/video-01/image-to-video
 
 # Remote API settings (applies to all API backends)
 remote_api_settings:
   max_retries: 3            # Maximum retry attempts
+  polling_interval: 5       # Queue status polling interval in seconds
+  http_timeout: 30          # Timeout for each queue API read
   timeout: 600              # Maximum wait time in seconds
   # fallback_backend: "wan2.1" # Fallback if primary API fails (comment out to disable fallback)
 
@@ -169,7 +182,7 @@ video_aspect_ratio: "16:9"  # Default to widescreen landscape
 
 # Video generation parameters (applies to all backends)
 segment_duration_seconds: 5.0 # Desired duration for each video segment in seconds
-# duration_seconds: 15        # Optional requested final runtime (max 14440s); Veo plans 4/6/8s clips and trims only if needed
+# duration_seconds: 15        # Optional requested final runtime (max 14440s); Veo/fal use profiled clip lengths and trim only if needed
 frame_num: 81         # Number of frames (for ~5 seconds at 16fps)
 sample_steps: 40      # Sampling steps
 sample_shift: 5.0     # Sampling shift factor

--- a/plans/workspace-recovery-and-roadmap.md
+++ b/plans/workspace-recovery-and-roadmap.md
@@ -1,7 +1,7 @@
 # TTV Pipeline Recovery and Product Roadmap
 
 Status: Phase 2 complete; Phase 3 pending
-Last updated: 2026-07-18
+Last updated: 2026-07-19
 Workspace: `/Users/magos/dev/kumanday/Parlina/ttv-pipeline`
 
 ## Purpose
@@ -37,6 +37,13 @@ compaction or a new Codex session.
   Veo request schema.
 - Treat user-facing `duration_seconds` as the requested final runtime. Keep
   provider clip duration as a separate internal concept.
+- Treat a narrative scene, its timed beats or shots, and a provider-generated
+  take as separate concepts. A longer generation may contain several shots, and
+  a longer scene may still require several generations.
+- Treat provider reference limits as budgets, not targets. Build a curated,
+  versioned reference pack for each scene from reusable project assets.
+- Keep audio references, independent audio timelines, splicing, muxing, and the
+  final mix in a separate phase from visual scene preparation and assembly.
 - Start frontend validation with a same-origin, zero-build UI. Add a frontend
   framework only when the proven workflow needs it.
 
@@ -271,54 +278,320 @@ Phase 2 validation:
   baseline failures for obsolete routes/fixtures and live readiness dependencies;
   no Phase 2 code path is implicated.
 
-## Phase 3 - Correct fal.ai support
+## Phase 3 - Make fal.ai a first-class provider
 
 Status: pending
+Priority: next product phase
+Execution: one bounded feature PR; split only if a model requires a materially
+different asset workflow
 
-Goal: keep fal as a useful provider without pretending every model shares one
-schema.
+Goal: make fal a reliable provider with explicit contracts for the video models
+the product uses, especially Seedance, without pretending every fal endpoint
+shares one input schema.
 
-Required work:
+### Current assessment
 
-- Fix the configured Hailuo path: it accepts 6 or 10 seconds, while the pipeline
-  currently sends 5.
-- Correct capability claims; the current adapter requires an image despite
-  advertising text-to-video.
-- Add request-payload assertions to tests.
-- Support only concrete model schemas needed by the product. Do not build a
-  universal adapter speculatively.
+- The current adapter sends one generic synchronous payload directly to
+  `fal.run`. It does not use fal's recommended durable queue lifecycle.
+- It retries every exception around the entire generation call. This can retry
+  authentication and validation failures and can resubmit an ambiguously
+  accepted paid job.
+- It always requires an input image while advertising text-to-video support.
+- It injects numeric `duration` and `image_url` fields into every endpoint even
+  though model field names, encodings, and allowed values differ.
+- The configured Hailuo-02 endpoint accepts 6 or 10 seconds, but the pipeline can
+  send 5.
+- Response parsing recursively accepts the first URL in any field instead of the
+  documented `video.url` output.
+- The current cost/timing header list is partly speculative. fal documents
+  request identity, billable units, queue metrics, and separate Platform APIs
+  that are better foundations for later usage analysis.
 
-## Phase 4 - Durable staged project/storyboard API
+### Design decisions
+
+- Keep one fal provider transport and a small table of concrete model profiles.
+  A profile owns its endpoint, supported generation mode, required assets,
+  duration contract, payload mapping, capability claims, and output mapping.
+- Continue accepting an exact `fal.model` endpoint ID, but require it to match a
+  tested profile. Fail configuration validation for unprofiled endpoints instead
+  of guessing their capabilities or payload fields.
+- Use fal's queue REST API through the already-installed `requests` dependency;
+  do not add `fal-client` unless the REST surface proves insufficient. Submit
+  once, retain the returned request and lifecycle URLs, poll status, retrieve the
+  result, and cancel on a local deadline where possible.
+- Keep this phase image-driven because that is the pipeline's current generation
+  contract. Do not advertise text-to-video, reference-to-video, extension, or
+  video editing until the pipeline exposes and tests those input roles. The
+  Seedance reference-to-video vertical slice follows the scene/reference domain
+  work in Phase 4 rather than expanding this provider-transport PR.
+- Parse the documented `video.url` result only. Preserve `video.content_type`,
+  `video.file_name`, `video.file_size`, and returned `seed` when present as
+  ephemeral provider metadata.
+- Make `FAL_KEY` the documented environment variable while retaining
+  `FAL_API_KEY` as a compatibility fallback.
+- Disable fal's implicit equivalent-model fallback for profiled requests so the
+  selected model, price, and capabilities remain deterministic; send
+  `x-app-fal-disable-fallback: true` and continue using the pipeline's explicit
+  provider fallback.
+- Disable remote input/output payload retention by default because requests can
+  contain prompts and base64 keyframes. Send `X-Fal-Store-IO: 0`; this does not
+  prevent later usage and billing reconciliation.
+- Make the existing requested-duration planner consume the selected profile's
+  allowed or fixed clip lengths instead of treating fal as one scalar maximum.
+
+### Initial first-class model profiles
+
+1. **Seedance 2.0 - priority vertical slice**
+   - Support `bytedance/seedance-2.0/image-to-video` and
+     `bytedance/seedance-2.0/fast/image-to-video`.
+   - Map the starting keyframe to `image_url` and the optional ending keyframe to
+     `end_image_url`.
+   - Accept integer durations from 4 through 15 seconds or `auto` when the user
+     did not request a runtime.
+   - Validate endpoint-specific resolution limits, aspect ratio, and image size
+     before submission.
+2. **Veo 3.1 through fal**
+   - Support `fal-ai/veo3.1/image-to-video` and
+     `fal-ai/veo3.1/first-last-frame-to-video`, including their fast variants
+     after confirming the live schemas are identical.
+   - Select the endpoint from the available keyframes instead of sending a last
+     frame to an image-only schema.
+   - Encode durations as `4s`, `6s`, or `8s` and map frames to `image_url` or
+     `first_frame_url` plus `last_frame_url` as required.
+3. **Hailuo-02 through fal**
+   - Correct the currently configured
+     `fal-ai/minimax/hailuo-02/standard/image-to-video` path.
+   - Encode duration as 6 or 10 seconds and map the optional ending keyframe to
+     `end_image_url`.
+   - Keep resolution constraints in the profile rather than a provider-wide
+     scalar maximum.
+4. **MiniMax Video-01 through fal**
+   - Support `fal-ai/minimax/video-01/image-to-video` with its documented
+     `prompt`, `image_url`, and `prompt_optimizer` schema.
+   - Treat it as a fixed six-second profile; reject incompatible requested clip
+     lengths rather than sending an unsupported duration field.
+   - Do not copy Hailuo duration or ending-frame fields into this older endpoint.
+
+Additional model variants should be one profile plus payload-contract tests, not
+new provider classes. The Hailuo and MiniMax names overlap in fal's catalog, so
+endpoint IDs are the authoritative identity.
+
+### Audio boundary
+
+- A profiled endpoint may return a video file that already contains model-native
+  audio. Phase 3 transports that file as one opaque video artifact; it does not
+  extract, replace, align, mix, or independently version its audio.
+- Do not add user-facing audio generation switches or audio reference inputs in
+  this phase. Record their presence in a released provider schema only so Phase
+  7 can make an explicit product decision later.
+- Narrative prompt text may still describe dialogue, ambience, or sound when a
+  model understands it. That does not create an audio timeline or editing
+  contract in the pipeline.
+
+### Queue, rate-limit, and retry behavior
+
+- Submit to `queue.fal.run` and retain `request_id`, `status_url`, `response_url`,
+  and `cancel_url` before polling.
+- Treat 400, 401, 403, 404, and model-validation 422 responses as non-retryable.
+- Detect 429 responses plus `X-Fal-Needs-Retry` and `X-Fal-Error-Type`. Honor
+  `Retry-After` when supplied; otherwise use capped exponential backoff with
+  jitter.
+- Retry only safe status/result reads and explicitly rejected submissions. Never
+  blindly repeat a submission after an ambiguous network failure or after a
+  `request_id` has been received.
+- Rely on fal's queue to retry accepted jobs for 429 concurrency limits, 503/504
+  failures, and runner connection errors. Do not wrap the entire queued job in
+  the generic local retry handler.
+- Bound queue-start time separately from the worker's total deadline. On local
+  timeout or cancellation, call fal's cancel URL and report that in-progress
+  cancellation is best-effort.
+- Surface fal's machine-readable `error_type` and model validation details in the
+  existing generator exception hierarchy without logging credentials or full
+  base64 inputs.
+
+### Seedance 2.5 release readiness
+
+As of 2026-07-19, fal describes Seedance 2.5 as announced but not released and
+says ByteDance has not published its full specification. Do not ship a guessed
+fal endpoint or payload.
+
+Release checklist:
+
+1. Confirm the endpoint ID and schema from the live fal model API page.
+2. Diff the released schema against the Seedance 2.0 profile.
+3. Add the smallest new profile, exact capability data, and mocked payload tests.
+4. Verify duration, reference limits, resolution, output format, cost units, and
+   whether the output contains native audio against fal's published values.
+5. Run one explicitly authorized paid smoke request before making 2.5 selectable
+   by default.
+
+The linked MuAPI-oriented community repository is a useful provisional watchlist,
+not an API contract. Recheck candidate fields such as `duration`, `resolution` or
+`ratio`, `output_format`, `bitrate_mode`, `camera_fixed`, `return_last_frame`,
+role-tagged reference assets, and `seed` only after fal publishes its own schema.
+Recheck `generate_audio` and audio-reference fields as inputs to the separate
+Phase 7 design rather than adding them to visual preparation opportunistically.
+
+### Observability and cost discovery, without metrics capture
+
+- Retain the fal `request_id` and exact `endpoint_id` because the queue lifecycle
+  needs them and a later metrics job can use them as reconciliation keys.
+- Document the future event fields now: submitted, processing-started, completed,
+  and downloaded timestamps; final status and `error_type`; queue
+  `metrics.inference_time`; and `X-Fal-Billable-Units`. Do not add a metrics
+  record, sidecar, or persistence path in this phase.
+- Identify but do not yet ingest these Platform API surfaces:
+  - `GET /v1/models/pricing` and `POST /v1/models/pricing/estimate`;
+  - `GET /v1/models/billing-events`, keyed by `request_id`;
+  - `GET /v1/models/usage` and `GET /v1/models/analytics`;
+  - `GET /v1/models/requests/by-endpoint` for timing and failure reconciliation.
+- Defer a database schema, scheduled ingestion, dashboards, alerts, cost
+  attribution, and webhook processing to later phases. The durable staged API
+  can add signed, idempotent webhooks when jobs no longer need a blocking worker.
+
+### Required work
+
+- [ ] Replace the direct synchronous call with queue submit/status/result/cancel.
+- [ ] Add the four concrete model profiles above and correct capability claims.
+- [ ] Route first and last keyframes and duration through the selected profile.
+- [ ] Remove generic payload injection and recursive URL discovery for profiled
+      endpoints.
+- [ ] Add rate-limit, safe-retry, deadline, cancellation, and typed-error handling.
+- [ ] Preserve only queue-required request identity for later reconciliation;
+      stop treating speculative headers as cost records.
+- [ ] Remove the current speculative metrics sidecar; metrics persistence remains
+      outside this phase.
+- [ ] Update sample configuration and provider documentation with supported
+      endpoint IDs and their capabilities.
+- [ ] Add mocked request-contract and queue-lifecycle tests.
+
+### Exit criteria
+
+- Seedance 2.0, fal Veo 3.1, Hailuo-02, and MiniMax Video-01 each produce the
+  documented payload for the keyframe inputs the profile claims to support.
+- Omitted duration preserves each model's automatic/default behavior; provided
+  duration is validated and encoded according to that model's contract.
+- Tests prove submit happens once, polling reaches completion, output uses
+  `video.url`, non-retryable errors fail immediately, retryable reads back off,
+  and timeout attempts cancellation.
+- Every generation exposes a fal request ID and endpoint ID for future billing
+  reconciliation without persisting prompts, images, API keys, or a new metrics
+  store.
+- Seedance 2.5 remains unavailable until the release checklist passes.
+
+Sources reviewed 2026-07-19:
+
+- [fal asynchronous queue and lifecycle](https://fal.ai/docs/documentation/model-apis/inference/queue)
+- [fal reliability and automatic retries](https://fal.ai/docs/documentation/model-apis/inference/reliability)
+- [fal platform headers](https://fal.ai/docs/documentation/model-apis/common-parameters)
+- [fal pricing and Platform APIs](https://fal.ai/docs/documentation/model-apis/pricing)
+- [Seedance 2.0 image-to-video schema](https://fal.ai/models/bytedance/seedance-2.0/image-to-video/api)
+- [Seedance 2.0 reference-to-video schema](https://fal.ai/models/bytedance/seedance-2.0/reference-to-video)
+- [Seedance 2.0 technical report](https://arxiv.org/abs/2604.14148)
+- [Veo 3.1 first/last-frame schema](https://fal.ai/models/fal-ai/veo3.1/first-last-frame-to-video/api)
+- [Hailuo-02 image-to-video schema](https://fal.ai/models/fal-ai/minimax/hailuo-02/standard/image-to-video/api)
+- [MiniMax Video-01 image-to-video schema](https://fal.ai/models/fal-ai/minimax/video-01/image-to-video/api)
+- [fal's Seedance 2.5 prerelease note](https://fal.ai/learn/tools/what-is-seedance-2-5)
+- [community Seedance 2.5/MuAPI field watchlist](https://github.com/Anil-matcha/awesome-seedance-2.5-api-prompts)
+
+## Phase 4 - Durable scene preparation and storyboard API
 
 Status: pending
 Execution: OpenSymphony/spec-driven
 
-Goal: replace the monolithic ephemeral job with a resumable project workflow.
+Goal: replace the monolithic ephemeral job with a resumable visual workflow that
+can plan short clips or longer scene takes without equating a generated clip with
+a single shot.
+
+### Core vocabulary
+
+- **Scene:** a narrative unit with a purpose, requested duration, entry state,
+  exit state, and relationship to adjacent scenes.
+- **Beat or shot:** a timed visual event inside a scene. Several beats may be
+  generated together in one provider request.
+- **Reference pack:** the curated, versioned set of project assets used for one
+  scene take. Provider limits are maximums, not a reason to include every asset.
+- **Take:** one provider-generated scene output plus its immutable prompt,
+  reference-pack snapshot, model, request identity, and selected trim range.
+- **Transition contract:** the intended relationship between adjacent selected
+  takes, such as a hard cut, match cut, continuous action, or dissolve.
 
 Initial architecture:
 
 - Store a project/storyboard manifest in existing Redis.
-- Store keyframes and segment-video versions in existing GCS.
+- Store reusable visual assets, keyframes, and take versions in existing GCS.
 - Add a database only when retention or query requirements exceed Redis.
-- Keep final render/stitch operations as ordinary jobs.
+- Keep visual render, trim, and stitch operations as ordinary jobs.
+- Keep the current code's segment terminology until the domain specification
+  decides whether a migration is worth the churn.
 
 Stages/actions:
 
-1. Create project and generate storyboard.
-2. Edit or replan storyboard segments.
-3. Generate all keyframes.
-4. Regenerate or prompt-edit one keyframe.
-5. Approve keyframes individually or in one batch.
-6. Render or regenerate individual video segments.
-7. Select approved segment versions and stitch the final video.
+1. Create a project from the brief and requested final duration.
+2. Decompose the story into scenes, then give each scene a timed beat or shot
+   plan that covers its requested duration.
+3. Create a project visual-asset library and automatically propose a small
+   reference pack for each scene. Let the user change only the proposed roles or
+   exceptions.
+4. Generate optional entry, beat, or exit keyframes where the selected model
+   benefits from anchors; do not require a keyframe at every edit boundary.
+5. Approve the scene packet: scene intent, timed beats, reference pack, anchors,
+   continuity state, and transition intent.
+6. Render or regenerate scene takes and retain every version.
+7. Select a take and trim range for each scene, then stitch the visual timeline
+   according to the transition contracts.
 
 Required semantics:
 
-- Version prompts, keyframes, and video segments; do not silently overwrite.
-- Changing shared boundary keyframe `N` invalidates the segments on both sides
-  that consume it.
+- Version scene plans, prompts, reference packs, keyframes, and takes; do not
+  silently overwrite.
+- A reference role belongs to its use in a scene, not permanently to the asset.
+  The same image or video may serve different roles in different scenes.
+- Preserve asset provenance and rights notes, and snapshot the exact asset
+  versions used by each paid generation.
+- Keep an explicit scene continuity ledger for character condition and position,
+  wardrobe, props, location, time, weather, lighting, screen direction, camera
+  grammar, and unresolved action.
+- Do not force the prior take's last frame into every following scene. Use it for
+  continuous action; use shared references or deliberate composition for hard
+  and match cuts.
+- Changing a shared boundary keyframe invalidates the takes on both sides that
+  consume it.
 - Expose provider/model capabilities so unsupported UI actions are hidden.
 - Make each stage resumable and safe to retry without duplicating paid jobs.
+- Allocate requested final duration to scenes first and provider-compatible
+  takes second. Trimming remains an explicit selected-take operation.
+
+### Seedance multimodal vertical slice
+
+After the Phase 3 fal transport is complete, use the live
+`bytedance/seedance-2.0/reference-to-video` endpoint to validate this domain with
+one bounded image/video-reference flow before Seedance 2.5 is released:
+
+- Support typed image and video references and their prompt aliases.
+- Enforce the released Seedance 2.0 limits rather than adopting reported 2.5
+  limits early.
+- Store the immutable reference-pack snapshot with the take and expose the
+  provider request ID for later cost reconciliation.
+- Exclude audio references and independent audio controls; those belong to Phase
+  7 even though the provider endpoint supports them.
+
+### Explicit audio exclusion
+
+Scene preparation may retain dialogue or sound intent as ordinary prompt text,
+and previews may play audio already muxed into a provider result. This phase does
+not define audio assets or reference roles, multiple audio timelines, track
+selection, extraction, synchronization, splicing, crossfades, loudness handling,
+or final muxing. Phase 7 owns that work against the selected visual timeline.
+
+Exit criteria:
+
+- The manifest distinguishes scenes, timed beats, reference packs, and takes.
+- The workflow can approve a scene packet, generate multiple takes, select a trim,
+  and re-stitch without rerendering unaffected scenes.
+- A Seedance 2.0 request proves image/video reference mapping and immutable take
+  provenance through the real staged API contract.
+- No audio-timeline or muxing semantics leak into the scene-preparation domain.
 
 ## Phase 5 - Low-touch frontend
 
@@ -331,11 +604,18 @@ high-value review points.
 Suggested UX:
 
 1. Brief: prompt, requested duration, provider/model, aspect ratio.
-2. Storyboard: editable segment cards with a single accept-all path.
-3. Keyframes: generate all, then one gallery review gate with approve-all,
-   regenerate, and edit-with-instructions controls.
-4. Render: per-segment previews and exception-based retry/edit controls.
-5. Final stitch and playback.
+2. Storyboard: editable scene cards with timed beats and one accept-all path.
+3. References: automatically propose each scene's visual reference pack and show
+   only conflicts, missing roles, provenance warnings, or user-requested changes.
+4. Anchors: offer one gallery review gate for optional entry, beat, and exit
+   keyframes, with approve-all, regenerate, and edit-with-instructions controls.
+5. Render: show scene takes with exception-based retry/edit controls, trim
+   selection, and the intended transition to the next scene.
+6. Final visual stitch and playback.
+
+The primary review object is a scene packet, not an individual short segment.
+Audio already embedded in a provider preview may play, but this frontend phase
+does not expose track, splice, mix, or mux controls.
 
 Implementation order:
 
@@ -343,33 +623,84 @@ Implementation order:
 - Adopt React or another framework only after the staged workflow demonstrates
   that native UI state management is the constraint.
 
-## Phase 6 - Instruction-based video-to-video editing
+## Phase 6 - Scene revision, extension, and repair
 
 Status: pending
 Execution: provider spike first; OpenSymphony/spec-driven if retained
 
-Goal: regenerate an individual segment from its current video plus natural
-language instructions.
+Goal: revise an individual selected scene take without rerendering unrelated
+scenes.
 
 Approach:
 
 - Spike one concrete provider/model first; fal Kling O1 is the current candidate.
 - Do not force video editing through the image-to-video generator interface.
-- Keep original and edited segment versions.
-- Require review before an edit becomes the selected segment.
-- Re-stitch without rerendering unaffected segments.
+- Support the smallest useful operation exposed by the chosen model: regenerate
+  with instructions, replace the visual reference pack, extend the take, or edit
+  a temporal region.
+- Keep original and revised take versions plus their instruction deltas.
+- Require review before a revision becomes the selected take.
+- Re-stitch without rerendering unaffected scenes.
 - Generalize the provider contract only after a second implementation proves
   that schemas share useful structure.
+- Preserve provider-native audio opaquely with the video artifact; audio repair
+  and reassembly remain Phase 7 work.
+
+## Phase 7 - Audio timelines, splicing, and final mux
+
+Status: pending
+Execution: provider/audio spike first; OpenSymphony/spec-driven if retained
+
+Goal: add explicit audio semantics after the selected visual scene timeline is
+stable, without coupling audio architecture to scene-preparation work.
+
+Inputs from earlier phases:
+
+- Selected visual scene takes, trim ranges, and transition contracts.
+- Provider-native muxed audio where present, treated as an optional source.
+- Narrative dialogue, music, ambience, and sound-effect intent retained as text.
+
+Required work:
+
+- Decide when provider-native audio is retained, extracted, muted, or replaced.
+- Define separate dialogue, music, ambience, and sound-effect tracks or timelines
+  only where the product workflow demonstrates that they are needed.
+- Add audio reference assets and provider audio-reference routing here, including
+  provenance and rights metadata.
+- Define trim, splice, crossfade, synchronization, sample-rate/channel handling,
+  loudness policy, and deterministic final mux behavior.
+- Preserve audio source and mix versions so revising one scene or track does not
+  overwrite approved work.
+- Rebuild the final audio/video output without regenerating unaffected video.
+
+Non-goals:
+
+- Do not redesign scene decomposition, visual reference packs, keyframe review,
+  or video-provider transport in this phase.
+- Do not add a full digital-audio-workstation interface; expose only the controls
+  proven necessary by the selected workflow.
+
+Exit criteria:
+
+- The same selected visual timeline can be rendered with a deterministic,
+  versioned audio mix.
+- Scene trims and transitions produce synchronized audio edits without modifying
+  the underlying selected video takes.
+- Model-native audio and independently supplied tracks have explicit, testable
+  precedence rather than implicit ffmpeg behavior.
 
 ## Deferred specifications
 
 Create these only after the outline and relevant spike are approved:
 
-- Veo 3.1 and requested-duration implementation spec.
 - Durable project/storyboard domain and API spec.
+- Scene, beat, reference-pack, take, continuity, and transition semantics.
+- Visual reference asset provenance and versioning spec.
 - Artifact versioning and invalidation spec.
 - Full HITL frontend interaction spec.
-- Video-to-video editing spec, conditional on spike results.
+- Scene revision/extension/editing spec, conditional on spike results.
+- Audio timeline, splicing, and final-mux spec, kept independent from the visual
+  preparation specifications above.
 
 ## Execution log
 
@@ -384,3 +715,22 @@ Create these only after the outline and relevant spike are approved:
   `/Users/magos/.Trash/ttv-pipeline-phase0-2026-07-18`.
 - Moved TLS material under ignored `certs/`, secured Git/Docker exclusions,
   normalized runtime credential paths, and preserved required Compose config.
+
+### 2026-07-19
+
+- Re-scoped Phase 3 from a Hailuo payload fix into first-class fal provider work
+  with explicit Seedance 2.0, Veo 3.1, Hailuo-02, and MiniMax Video-01 profiles.
+- Selected fal's durable queue lifecycle and model-specific duration planning;
+  documented safe retry, rate-limit, cancellation, and error semantics.
+- Confirmed from fal's current prerelease note that Seedance 2.5 is not yet
+  released and recorded a release checklist instead of inventing a fal schema.
+- Identified request identity and Platform API reconciliation points for later
+  timing and cost analysis while keeping metrics capture out of Phase 3.
+- Reframed the future workflow around scenes, timed beats, curated visual
+  reference packs, versioned takes, continuity state, and transition contracts
+  so longer model outputs do not remain synonymous with shots.
+- Added a bounded Seedance 2.0 image/video-reference vertical slice after the fal
+  transport work, while keeping the unreleased Seedance 2.5 limits gated.
+- Isolated audio references, audio timelines, splicing, mixing, and final muxing
+  in Phase 7 so visual preparation and review phases remain modular.
+- No Phase 3 implementation changes were made.

--- a/plans/workspace-recovery-and-roadmap.md
+++ b/plans/workspace-recovery-and-roadmap.md
@@ -1,6 +1,6 @@
 # TTV Pipeline Recovery and Product Roadmap
 
-Status: Phase 2 complete; Phase 3 pending
+Status: Phase 3 complete; Phase 4 pending
 Last updated: 2026-07-19
 Workspace: `/Users/magos/dev/kumanday/Parlina/ttv-pipeline`
 
@@ -280,7 +280,7 @@ Phase 2 validation:
 
 ## Phase 3 - Make fal.ai a first-class provider
 
-Status: pending
+Status: complete
 Priority: next product phase
 Execution: one bounded feature PR; split only if a model requires a materially
 different asset workflow
@@ -451,19 +451,19 @@ Phase 7 design rather than adding them to visual preparation opportunistically.
 
 ### Required work
 
-- [ ] Replace the direct synchronous call with queue submit/status/result/cancel.
-- [ ] Add the four concrete model profiles above and correct capability claims.
-- [ ] Route first and last keyframes and duration through the selected profile.
-- [ ] Remove generic payload injection and recursive URL discovery for profiled
+- [x] Replace the direct synchronous call with queue submit/status/result/cancel.
+- [x] Add the four concrete model profiles above and correct capability claims.
+- [x] Route first and last keyframes and duration through the selected profile.
+- [x] Remove generic payload injection and recursive URL discovery for profiled
       endpoints.
-- [ ] Add rate-limit, safe-retry, deadline, cancellation, and typed-error handling.
-- [ ] Preserve only queue-required request identity for later reconciliation;
+- [x] Add rate-limit, safe-retry, deadline, cancellation, and typed-error handling.
+- [x] Preserve only queue-required request identity for later reconciliation;
       stop treating speculative headers as cost records.
-- [ ] Remove the current speculative metrics sidecar; metrics persistence remains
+- [x] Remove the current speculative metrics sidecar; metrics persistence remains
       outside this phase.
-- [ ] Update sample configuration and provider documentation with supported
+- [x] Update sample configuration and provider documentation with supported
       endpoint IDs and their capabilities.
-- [ ] Add mocked request-contract and queue-lifecycle tests.
+- [x] Add mocked request-contract and queue-lifecycle tests.
 
 ### Exit criteria
 
@@ -478,6 +478,18 @@ Phase 7 design rather than adding them to visual preparation opportunistically.
   reconciliation without persisting prompts, images, API keys, or a new metrics
   store.
 - Seedance 2.5 remains unavailable until the release checklist passes.
+
+Phase 3 validation:
+
+- `uv run pytest tests/test_fal_generator.py tests/test_veo31_duration.py -q`:
+  34 passed on Python 3.14.3.
+- `uv run ruff check generators/remote/fal_generator.py
+  tests/test_fal_generator.py`: passed.
+- `uv run mypy --follow-imports=skip generators/remote/fal_generator.py`: passed.
+- `uv run pytest -q`: 373 passed, 103 failed, 4 skipped. The failures reproduce
+  the existing unrelated baseline around absent Angie assets, legacy API test
+  fixtures without Redis/GCS readiness, and Trio compatibility; no fal or
+  requested-duration test failed.
 
 Sources reviewed 2026-07-19:
 
@@ -733,4 +745,8 @@ Create these only after the outline and relevant spike are approved:
   transport work, while keeping the unreleased Seedance 2.5 limits gated.
 - Isolated audio references, audio timelines, splicing, mixing, and final muxing
   in Phase 7 so visual preparation and review phases remain modular.
-- No Phase 3 implementation changes were made.
+- Implemented the first-class fal provider on `feat/fal-first-class-provider`:
+  eight released endpoint IDs across four model families, queue lifecycle,
+  safe retry and cancellation, exact payload/output contracts, profiled duration
+  planning, ephemeral reconciliation metadata, updated configuration/docs, and
+  mocked contract/lifecycle coverage. Seedance 2.5 remains release-gated.

--- a/tests/mocks/mock_redis.py
+++ b/tests/mocks/mock_redis.py
@@ -96,7 +96,11 @@ class MockJobQueue:
             id=job_id,
             status=JobStatus.QUEUED,
             created_at=created_at,
-            prompt=request.prompt,
+            prompt=(
+                request.prompt
+                or effective_config.get("prompt")
+                or "Resumed from reviewed prompt plan"
+            ),
             config=redact_config_secrets(effective_config)
         )
         

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -1,6 +1,7 @@
 import inspect
 from unittest.mock import Mock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from api.config import APIConfig, GCSConfig
@@ -111,6 +112,67 @@ def test_api_resumes_trimmed_plan_without_repeating_duration():
     stored_job = queue.get_job(response.json()["id"])
     assert stored_job.config["duration_seconds"] == 9
     assert "ending keyframe will not appear" in response.json()["warnings"][0]
+
+
+def test_api_exact_reviewed_plan_clears_inherited_duration():
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "veo3",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+            "duration_seconds": 8,
+        },
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+
+    response = TestClient(app).post(
+        "/v1/jobs", json={"enhanced_prompt": reviewed_plan()}
+    )
+
+    assert response.status_code == 202
+    stored_job = queue.get_job(response.json()["id"])
+    assert "duration_seconds" not in stored_job.config
+
+
+@pytest.mark.parametrize(
+    ("duration", "prompt", "message"),
+    [
+        (10, "move", "Minimax durations"),
+        (4, "x" * 501, "Minimax prompts"),
+    ],
+)
+def test_api_rejects_invalid_minimax_plan_before_enqueue(duration, prompt, message):
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "minimax",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+            "minimax": {"max_duration": 6},
+        },
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+    plan = reviewed_plan()
+    plan["segmentation_logic"]["total_duration_seconds"] = duration
+    plan["video_prompts"][0].update(
+        prompt=prompt, duration_seconds=duration
+    )
+
+    with patch.object(queue, "enqueue_job") as enqueue_job:
+        response = TestClient(app).post(
+            "/v1/jobs", json={"enhanced_prompt": plan}
+        )
+
+    assert response.status_code == 422
+    assert message in response.text
+    enqueue_job.assert_not_called()
 
 
 def test_api_rejects_reviewed_plan_frame_paths():

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -1,10 +1,12 @@
-from unittest.mock import patch
+import inspect
+from unittest.mock import Mock, patch
 
 from fastapi.testclient import TestClient
 
 from api.config import APIConfig, GCSConfig
 from api.main import create_app
 from api.models import JobStatus
+from api.routes.jobs import create_plan
 from tests.mocks.mock_redis import MockJobQueue, MockRedisManager
 from workers.video_worker import process_video_job
 
@@ -89,6 +91,53 @@ def test_api_rejects_reviewed_plan_frame_paths():
 
     assert response.status_code == 422
     assert "Frame references must be filenames" in response.text
+
+
+def test_storyboard_job_exposes_generic_artifact_metadata():
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "veo3",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+        },
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+    client = TestClient(app)
+
+    assert not inspect.iscoroutinefunction(create_plan)
+
+    response = client.post(
+        "/v1/jobs",
+        json={"enhanced_prompt": reviewed_plan(), "keyframes_only": True},
+    )
+    job_id = response.json()["id"]
+    gcs_uri = f"gs://test-bucket/ttv-api/{job_id}/keyframe_storyboard.zip"
+    queue.update_job_status(job_id, JobStatus.FINISHED, gcs_uri=gcs_uri)
+    gcs_client = Mock()
+    gcs_client.generate_signed_url.return_value = "https://example.com/storyboard"
+
+    with patch("api.gcs_client.create_gcs_client", return_value=gcs_client):
+        artifact = client.get(f"/v1/jobs/{job_id}/artifact-url")
+
+    assert artifact.status_code == 200
+    assert artifact.json()["artifact_name"] == "keyframe_storyboard.zip"
+    assert artifact.json()["mime_type"] == "application/zip"
+    assert artifact.json()["artifact_url"] == "https://example.com/storyboard"
+    assert "video_url" not in artifact.json()
+
+    queue.update_job_status(
+        job_id,
+        JobStatus.FINISHED,
+        gcs_uri=f"gs://test-bucket/ttv-api/{job_id}/final_video.mp4",
+    )
+    with patch("api.gcs_client.create_gcs_client", return_value=gcs_client):
+        video = client.get(f"/v1/jobs/{job_id}/video-url")
+    assert video.json()["mime_type"] == "video/mp4"
+    assert video.json()["video_url"] == "https://example.com/storyboard"
 
 
 def test_mocked_api_job_reaches_worker_with_effective_config():

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -93,6 +93,55 @@ def test_api_rejects_reviewed_plan_frame_paths():
     assert "Frame references must be filenames" in response.text
 
 
+def test_api_validates_reviewed_plan_before_enqueue():
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "veo3",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+        },
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+    plan = reviewed_plan()
+    plan["video_prompts"][0]["duration_seconds"] = 6
+
+    with patch.object(queue, "enqueue_job") as enqueue_job:
+        response = TestClient(app).post(
+            "/v1/jobs",
+            json={"duration_seconds": 4, "enhanced_prompt": plan},
+        )
+
+    assert response.status_code == 422
+    assert "requested segment plan" in response.text
+    enqueue_job.assert_not_called()
+
+
+def test_api_rejects_plan_creation_without_enhancer_credentials():
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "veo3",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+        },
+    )
+    app = create_app()
+    app.state.config = api_config
+
+    with patch.dict("os.environ", {"OPENAI_API_KEY": ""}), patch(
+        "pipeline.enhance_prompt_data"
+    ) as enhance:
+        response = TestClient(app).post("/v1/plans", json={"prompt": "test"})
+
+    assert response.status_code == 503
+    assert "Prompt enhancement credentials are not configured" in response.text
+    enhance.assert_not_called()
+
+
 def test_storyboard_job_exposes_generic_artifact_metadata():
     api_config = APIConfig(
         gcs=GCSConfig(bucket="test-bucket"),

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -79,6 +79,18 @@ def test_api_creates_and_resumes_reviewed_plan():
     assert storyboard_job.config["keyframes_only"] is True
 
 
+def test_api_rejects_reviewed_plan_frame_paths():
+    app = create_app()
+    client = TestClient(app)
+    plan = reviewed_plan()
+    plan["video_prompts"][0]["first_frame"] = "/tmp/private.png"
+
+    response = client.post("/v1/jobs", json={"enhanced_prompt": plan})
+
+    assert response.status_code == 422
+    assert "Frame references must be filenames" in response.text
+
+
 def test_mocked_api_job_reaches_worker_with_effective_config():
     pipeline_config = {
         "prompt": "default prompt",

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -9,6 +9,76 @@ from tests.mocks.mock_redis import MockJobQueue, MockRedisManager
 from workers.video_worker import process_video_job
 
 
+def reviewed_plan():
+    return {
+        "segmentation_logic": {
+            "total_duration_seconds": 4,
+            "number_of_segments": 1,
+            "reasoning": "reviewed",
+        },
+        "keyframe_prompts": [{"segment": 1, "prompt": "frame"}],
+        "video_prompts": [{
+            "segment": 1,
+            "prompt": "move",
+            "first_frame": "provided_start_image.png",
+            "last_frame": "segment_01.png",
+            "duration_seconds": 4,
+        }],
+    }
+
+
+def test_api_creates_and_resumes_reviewed_plan():
+    pipeline_config = {
+        "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "openai_api_key": "test-secret",
+    }
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config=pipeline_config,
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+    client = TestClient(app)
+    plan = reviewed_plan()
+    long_prompt = "# Brief\n\n" + "A" * 3000
+
+    with patch("pipeline.enhance_prompt_data", return_value=plan) as enhance:
+        plan_response = client.post(
+            "/v1/plans",
+            json={"prompt": long_prompt, "duration_seconds": 4},
+        )
+
+    assert plan_response.status_code == 200
+    assert plan_response.json() == plan
+    assert enhance.call_args.args[0] == long_prompt
+    assert enhance.call_args.args[1]["duration_seconds"] == 4
+
+    create_response = client.post(
+        "/v1/jobs",
+        json={"duration_seconds": 4, "enhanced_prompt": plan},
+    )
+    assert create_response.status_code == 202
+    stored_job = queue.get_job(create_response.json()["id"])
+    assert stored_job.prompt == "Resumed from reviewed prompt plan"
+    assert stored_job.config["enhanced_prompt"] == plan
+
+    storyboard_response = client.post(
+        "/v1/jobs",
+        json={
+            "duration_seconds": 4,
+            "enhanced_prompt": plan,
+            "keyframes_only": True,
+        },
+    )
+    assert storyboard_response.status_code == 202
+    storyboard_job = queue.get_job(storyboard_response.json()["id"])
+    assert storyboard_job.config["keyframes_only"] is True
+
+
 def test_mocked_api_job_reaches_worker_with_effective_config():
     pipeline_config = {
         "prompt": "default prompt",

--- a/tests/test_api_job_smoke.py
+++ b/tests/test_api_job_smoke.py
@@ -81,6 +81,38 @@ def test_api_creates_and_resumes_reviewed_plan():
     assert storyboard_job.config["keyframes_only"] is True
 
 
+def test_api_resumes_trimmed_plan_without_repeating_duration():
+    api_config = APIConfig(
+        gcs=GCSConfig(bucket="test-bucket"),
+        pipeline_config={
+            "default_backend": "veo3",
+            "generation_mode": "keyframe",
+            "single_keyframe_mode": True,
+        },
+    )
+    queue = MockJobQueue(MockRedisManager(api_config.redis))
+    app = create_app()
+    app.state.config = api_config
+    app.state.job_queue = queue
+    plan = reviewed_plan()
+    plan["segmentation_logic"].update(total_duration_seconds=9, number_of_segments=2)
+    plan["keyframe_prompts"].append({"segment": 2, "prompt": "frame 2"})
+    plan["video_prompts"].append({
+        "segment": 2,
+        "prompt": "move 2",
+        "first_frame": "segment_01.png",
+        "last_frame": "segment_02.png",
+        "duration_seconds": 6,
+    })
+
+    response = TestClient(app).post("/v1/jobs", json={"enhanced_prompt": plan})
+
+    assert response.status_code == 202
+    stored_job = queue.get_job(response.json()["id"])
+    assert stored_job.config["duration_seconds"] == 9
+    assert "ending keyframe will not appear" in response.json()["warnings"][0]
+
+
 def test_api_rejects_reviewed_plan_frame_paths():
     app = create_app()
     client = TestClient(app)

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -1,102 +1,454 @@
-import json
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
+import requests
+from PIL import Image
+
 from generators.factory import create_video_generator
 from generators.remote.fal_generator import FalGenerator
+from pipeline import (
+    build_prompt_enhancement_instructions,
+    get_duration_tradeoff,
+    get_requested_segment_plan,
+    plan_provider_segment_durations,
+    validate_prompt_enhancement,
+)
+from video_generator_interface import APIError, GenerationTimeoutError, InvalidInputError
 
 
-def test_extract_response_metrics_parses_cost_and_time_headers():
-    generator = FalGenerator({"api_key": "test-key", "model": "fal-ai/test-model"})
+def _response(status_code, payload, headers=None):
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json.return_value = payload
+    return response
 
-    metrics = generator._extract_response_metrics(
-        {
-            "x-fal-request-id": "req_123",
-            "x-compute-time": "2.31",
-            "x-queue-time": "0.19",
-            "x-total-cost": "0.048",
-            "x-request-cost": "0.048",
-        }
+
+def _images(tmp_path):
+    first = tmp_path / "first.png"
+    last = tmp_path / "last.png"
+    Image.new("RGB", (128, 72)).save(first)
+    Image.new("RGB", (128, 72)).save(last)
+    return first, last
+
+
+def _install_completed_queue(monkeypatch, endpoint, result=None, statuses=None):
+    request_id = "req_123"
+    request_base = f"https://queue.fal.run/{endpoint}/requests/{request_id}"
+    calls = []
+    status_responses = iter(
+        statuses or [_response(200, {"status": "COMPLETED", "metrics": {"inference_time": 2.5}})]
     )
 
-    assert metrics["request_id"] == "req_123"
-    assert metrics["compute_time"] == 2.31
-    assert metrics["queue_time"] == 0.19
-    assert metrics["total_cost"] == 0.048
-    assert metrics["request_cost"] == 0.048
+    def request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        if method == "POST":
+            return _response(
+                200,
+                {
+                    "request_id": request_id,
+                    "status_url": f"{request_base}/status",
+                    "response_url": f"{request_base}/response",
+                    "cancel_url": f"{request_base}/cancel",
+                },
+            )
+        if url.endswith("/status"):
+            return next(status_responses)
+        return _response(
+            200,
+            result
+            or {
+                "video": {
+                    "url": "https://cdn.example.com/video.mp4",
+                    "content_type": "video/mp4",
+                    "file_size": 42,
+                },
+                "seed": 7,
+            },
+            {"X-Fal-Billable-Units": "6"},
+        )
 
+    monkeypatch.setattr("generators.remote.fal_generator.requests.request", request)
 
-def test_generate_video_extracts_url_and_writes_metrics_sidecar(monkeypatch, tmp_path):
-    generator = FalGenerator(
-        {
-            "api_key": "test-key",
-            "model": "fal-ai/test-model",
-            "timeout": 10,
-            "max_retries": 1,
-        }
-    )
-
-    input_image = tmp_path / "input.png"
-    input_image.write_bytes(b"image")
-    output_path = tmp_path / "output.mp4"
-
-    monkeypatch.setattr(
-        "generators.remote.fal_generator.ImageValidator.validate_image",
-        lambda *_args, **_kwargs: {"valid": True, "errors": []},
-    )
-
-    response = Mock()
-    response.status_code = 200
-    response.headers = {
-        "x-fal-request-id": "req_abc",
-        "x-compute-time": "1.2",
-        "x-total-cost": "0.01",
-    }
-    response.json.return_value = {
-        "output": {
-            "video": {
-                "url": "https://cdn.example.com/video.mp4",
-            }
-        }
-    }
-
-    monkeypatch.setattr("generators.remote.fal_generator.requests.post", lambda *args, **kwargs: response)
-
-    def _fake_download(url: str, destination: str) -> None:
+    def download(url, destination):
         assert url == "https://cdn.example.com/video.mp4"
         Path(destination).write_bytes(b"video")
 
-    monkeypatch.setattr("generators.remote.fal_generator.download_file", _fake_download)
+    monkeypatch.setattr("generators.remote.fal_generator.download_file", download)
+    return calls
 
-    result_path = generator.generate_video(
-        prompt="test prompt",
-        input_image_path=str(input_image),
-        output_path=str(output_path),
-        duration=5,
+
+@pytest.mark.parametrize(
+    ("configured_model", "actual_model", "duration", "default_input", "expected_fields"),
+    [
+        (
+            "bytedance/seedance-2.0/image-to-video",
+            "bytedance/seedance-2.0/image-to-video",
+            12,
+            {"resolution": "1080p", "aspect_ratio": "16:9"},
+            {"duration": 12, "image_url": True, "end_image_url": True},
+        ),
+        (
+            "fal-ai/veo3.1/image-to-video",
+            "fal-ai/veo3.1/first-last-frame-to-video",
+            6,
+            {"resolution": "720p"},
+            {"duration": "6s", "first_frame_url": True, "last_frame_url": True},
+        ),
+        (
+            "fal-ai/veo3.1/fast/image-to-video",
+            "fal-ai/veo3.1/fast/first-last-frame-to-video",
+            8,
+            {},
+            {"duration": "8s", "first_frame_url": True, "last_frame_url": True},
+        ),
+        (
+            "fal-ai/minimax/hailuo-02/standard/image-to-video",
+            "fal-ai/minimax/hailuo-02/standard/image-to-video",
+            10,
+            {"resolution": "768P"},
+            {"duration": "10", "image_url": True, "end_image_url": True},
+        ),
+        (
+            "fal-ai/minimax/video-01/image-to-video",
+            "fal-ai/minimax/video-01/image-to-video",
+            6,
+            {"prompt_optimizer": False},
+            {"image_url": True},
+        ),
+    ],
+)
+def test_profiled_payloads_use_queue_and_documented_fields(
+    monkeypatch,
+    tmp_path,
+    configured_model,
+    actual_model,
+    duration,
+    default_input,
+    expected_fields,
+):
+    first, last = _images(tmp_path)
+    output = tmp_path / "output.mp4"
+    calls = _install_completed_queue(monkeypatch, actual_model)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": configured_model,
+            "default_input": default_input,
+            "polling_interval": 0,
+        }
     )
 
-    assert result_path == str(output_path)
-    assert output_path.exists()
-    assert generator.last_request_metrics["request_id"] == "req_abc"
-    metrics_sidecar = tmp_path / "output.mp4.metrics.json"
-    assert metrics_sidecar.exists()
-    sidecar = json.loads(metrics_sidecar.read_text())
-    assert sidecar["total_cost"] == 0.01
+    result = generator.generate_video(
+        prompt="move",
+        input_image_path=str(first),
+        last_frame_path=str(last),
+        output_path=str(output),
+        duration=duration,
+    )
 
+    assert result == str(output)
+    submit = calls[0]
+    assert submit[0] == "POST"
+    assert submit[1] == f"https://queue.fal.run/{actual_model}"
+    payload = submit[2]["json"]
+    assert payload["prompt"] == "move"
+    assert all(
+        payload[name] == value if value is not True else name in payload
+        for name, value in expected_fields.items()
+    )
+    assert "generate_audio" not in payload
+    if configured_model.endswith("video-01/image-to-video"):
+        assert "duration" not in payload
+        assert "end_image_url" not in payload
 
-def test_factory_creates_fal_generator_from_provider_backend_name():
-    config = {
-        "fal": {
-            "api_key": "test-key",
-            "model": "fal-ai/test-model",
-        },
-        "remote_api_settings": {
-            "max_retries": 1,
-            "timeout": 10,
-        },
+    headers = submit[2]["headers"]
+    assert headers["Authorization"] == "Key test-key"
+    assert headers["X-Fal-Store-IO"] == "0"
+    assert headers["x-app-fal-disable-fallback"] == "true"
+    assert generator.last_request_metadata == {
+        "request_id": "req_123",
+        "endpoint_id": actual_model,
+        "status_url": f"https://queue.fal.run/{actual_model}/requests/req_123/status",
+        "response_url": f"https://queue.fal.run/{actual_model}/requests/req_123/response",
+        "cancel_url": f"https://queue.fal.run/{actual_model}/requests/req_123/cancel",
+        "status": "COMPLETED",
+        "metrics": {"inference_time": 2.5},
+        "video": {"content_type": "video/mp4", "file_size": 42},
+        "seed": 7,
+        "billable_units": "6",
     }
 
-    generator = create_video_generator("fal.ai", config)
+
+@pytest.mark.parametrize(
+    ("model", "expected_duration"),
+    [
+        ("bytedance/seedance-2.0/image-to-video", "auto"),
+        ("fal-ai/veo3.1/image-to-video", None),
+        ("fal-ai/minimax/hailuo-02/standard/image-to-video", None),
+        ("fal-ai/minimax/video-01/image-to-video", None),
+    ],
+)
+def test_omitted_duration_preserves_profile_default(
+    monkeypatch, tmp_path, model, expected_duration
+):
+    first, _ = _images(tmp_path)
+    calls = _install_completed_queue(monkeypatch, model)
+    generator = FalGenerator({"api_key": "test-key", "model": model})
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), duration=None)
+
+    payload = calls[0][2]["json"]
+    if expected_duration is None:
+        assert "duration" not in payload
+    else:
+        assert payload["duration"] == expected_duration
+
+
+def test_submit_is_not_retried_after_ambiguous_network_failure(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    request = Mock(side_effect=requests.ConnectionError("connection lost"))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.request", request)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": "bytedance/seedance-2.0/image-to-video",
+            "max_retries": 3,
+        }
+    )
+
+    with pytest.raises(APIError, match="outcome is unknown"):
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    assert request.call_count == 1
+
+
+def test_explicitly_rejected_submission_is_retried(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    request_id = "req_retry"
+    request_base = f"https://queue.fal.run/{endpoint}/requests/{request_id}"
+    responses = iter(
+        [
+            _response(429, {"error": "busy"}, {"X-Fal-Needs-Retry": "true"}),
+            _response(
+                200,
+                {
+                    "request_id": request_id,
+                    "status_url": f"{request_base}/status",
+                    "response_url": f"{request_base}/response",
+                    "cancel_url": f"{request_base}/cancel",
+                },
+            ),
+            _response(200, {"status": "COMPLETED"}),
+            _response(200, {"video": {"url": "https://cdn.example.com/video.mp4"}}),
+        ]
+    )
+    request = Mock(side_effect=lambda *_args, **_kwargs: next(responses))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.request", request)
+    monkeypatch.setattr("generators.remote.fal_generator.time.sleep", lambda *_: None)
+    monkeypatch.setattr("generators.remote.fal_generator.random.uniform", lambda *_: 0)
+    monkeypatch.setattr(
+        "generators.remote.fal_generator.download_file",
+        lambda _url, destination: Path(destination).write_bytes(b"video"),
+    )
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint, "max_retries": 2})
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    assert request.call_count == 4
+
+
+def test_veo_first_last_profile_falls_back_to_image_endpoint_without_last_frame(
+    monkeypatch, tmp_path
+):
+    first, _ = _images(tmp_path)
+    actual = "fal-ai/veo3.1/image-to-video"
+    calls = _install_completed_queue(monkeypatch, actual)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": "fal-ai/veo3.1/first-last-frame-to-video",
+        }
+    )
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 4)
+
+    assert calls[0][1] == f"https://queue.fal.run/{actual}"
+    assert "image_url" in calls[0][2]["json"]
+
+
+def test_validation_error_is_not_retried_and_exposes_error_type(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    request = Mock(
+        return_value=_response(
+            422,
+            {"detail": "invalid duration", "error_type": "model_validation"},
+            {"X-Fal-Needs-Retry": "true"},
+        )
+    )
+    monkeypatch.setattr("generators.remote.fal_generator.requests.request", request)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": "bytedance/seedance-2.0/image-to-video",
+            "max_retries": 3,
+        }
+    )
+
+    with pytest.raises(APIError, match="invalid duration") as caught:
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    assert request.call_count == 1
+    assert caught.value.status_code == 422
+    assert caught.value.error_type == "model_validation"
+
+
+def test_retryable_status_read_honors_retry_after_without_resubmitting(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    calls = _install_completed_queue(
+        monkeypatch,
+        endpoint,
+        statuses=[
+            _response(429, {"error": "busy"}, {"Retry-After": "0"}),
+            _response(200, {"status": "COMPLETED"}),
+        ],
+    )
+    sleeps = []
+    monkeypatch.setattr("generators.remote.fal_generator.time.sleep", sleeps.append)
+    monkeypatch.setattr("generators.remote.fal_generator.random.uniform", lambda *_: 0)
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint, "max_retries": 2})
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    assert sum(method == "POST" for method, *_ in calls) == 1
+    assert sleeps == [0]
+
+
+def test_timeout_attempts_best_effort_cancellation(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    _install_completed_queue(
+        monkeypatch,
+        endpoint,
+        statuses=[_response(200, {"status": "IN_QUEUE"})],
+    )
+    cancel = Mock(return_value=_response(202, {"status": "CANCELLATION_REQUESTED"}))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.put", cancel)
+    monkeypatch.setattr(
+        "generators.remote.fal_generator.time.monotonic", Mock(side_effect=[0, 0, 1])
+    )
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint, "timeout": 0.1})
+
+    with pytest.raises(GenerationTimeoutError):
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    cancel.assert_called_once()
+    assert generator.last_request_metadata["cancellation_requested"] is True
+
+
+def test_strict_output_and_profile_input_validation(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    _install_completed_queue(
+        monkeypatch,
+        endpoint,
+        result={"output": {"url": "https://cdn.example.com/wrong.mp4"}},
+    )
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint})
+
+    with pytest.raises(Exception, match="video.url"):
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    with pytest.raises(InvalidInputError, match="generate_audio"):
+        generator.generate_video(
+            "move",
+            str(first),
+            str(tmp_path / "out.mp4"),
+            6,
+            fal_input={"generate_audio": False},
+        )
+
+
+def test_unprofiled_endpoint_fails_configuration_and_fal_key_is_preferred(monkeypatch):
+    with pytest.raises(Exception, match="Unsupported fal.ai model endpoint"):
+        FalGenerator({"api_key": "test-key", "model": "fal-ai/unknown"})
+
+    monkeypatch.setenv("FAL_KEY", "documented-key")
+    monkeypatch.setenv("FAL_API_KEY", "legacy-key")
+    generator = FalGenerator({"model": "bytedance/seedance-2.0/image-to-video"})
+    assert generator.api_key == "documented-key"
+    assert generator.get_capabilities()["supports_text_to_video"] is False
+
+
+def test_fal_duration_planning_and_llm_validation():
+    config = {
+        "default_backend": "fal",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "duration_seconds": 17,
+        "fal": {"model": "bytedance/seedance-2.0/image-to-video"},
+    }
+    assert plan_provider_segment_durations(17, tuple(range(4, 16))) == [13, 4]
+    assert plan_provider_segment_durations(17, (6, 10)) == [6, 6, 6]
+    assert plan_provider_segment_durations(17, (6,)) == [6, 6, 6]
+    maximum_plan = plan_provider_segment_durations(14_440, tuple(range(4, 16)))
+    assert sum(maximum_plan) == 14_440
+    assert get_requested_segment_plan(config) == [13, 4]
+
+    config["fal"]["model"] = "fal-ai/minimax/hailuo-02/standard/image-to-video"
+    assert get_requested_segment_plan(config) == [6, 6, 6]
+    config["fal"]["model"] = "fal-ai/minimax/video-01/image-to-video"
+    assert "final generated endpoint" in get_duration_tradeoff(config)
+    config["fal"]["model"] = "fal-ai/veo3.1/image-to-video"
+    assert get_requested_segment_plan(config) == [8, 4, 6]
+    config["fal"]["model"] = "bytedance/seedance-2.0/image-to-video"
+
+    result = {
+        "segmentation_logic": {
+            "total_duration_seconds": 17,
+            "number_of_segments": 2,
+            "reasoning": "requested runtime",
+        },
+        "keyframe_prompts": [
+            {"segment": 1, "prompt": "first"},
+            {"segment": 2, "prompt": "second"},
+        ],
+        "video_prompts": [
+            {
+                "segment": 1,
+                "prompt": "first",
+                "first_frame": "provided_start_image.png",
+                "last_frame": "segment_01.png",
+                "duration_seconds": 13,
+            },
+            {
+                "segment": 2,
+                "prompt": "second",
+                "first_frame": "segment_01.png",
+                "last_frame": "segment_02.png",
+                "duration_seconds": 4,
+            },
+        ],
+    }
+    validate_prompt_enhancement(result, config)
+    assert "duration_seconds values [13, 4]" in build_prompt_enhancement_instructions(config)
+    assert get_duration_tradeoff(config) is None
+
+
+def test_factory_creates_profiled_fal_generator():
+    model = "fal-ai/minimax/hailuo-02/standard/image-to-video"
+    generator = create_video_generator(
+        "fal.ai",
+        {
+            "fal": {"api_key": "test-key", "model": model},
+            "remote_api_settings": {"polling_interval": 2, "timeout": 10},
+        },
+    )
 
     assert isinstance(generator, FalGenerator)
-    assert generator.model == "fal-ai/test-model"
+    assert generator.model == model
+    assert generator.base_url == "https://queue.fal.run"
+    assert generator.polling_interval == 2

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -349,6 +349,43 @@ def test_timeout_attempts_best_effort_cancellation(monkeypatch, tmp_path):
     assert generator.last_request_metadata["cancellation_requested"] is True
 
 
+def test_in_flight_status_timeout_attempts_best_effort_cancellation(
+    monkeypatch, tmp_path
+):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    request_id = "req_timeout"
+    request_base = f"https://queue.fal.run/{endpoint}/requests/{request_id}"
+
+    def request(method, _url, **_kwargs):
+        if method == "POST":
+            return _response(
+                200,
+                {
+                    "request_id": request_id,
+                    "status_url": f"{request_base}/status",
+                    "response_url": f"{request_base}/response",
+                    "cancel_url": f"{request_base}/cancel",
+                },
+            )
+        raise requests.Timeout("status read exceeded its request timeout")
+
+    monkeypatch.setattr("generators.remote.fal_generator.requests.request", request)
+    cancel = Mock(return_value=_response(202, {"status": "CANCELLATION_REQUESTED"}))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.put", cancel)
+    monkeypatch.setattr(
+        "generators.remote.fal_generator.time.monotonic",
+        Mock(side_effect=[0, 0, 0, 1]),
+    )
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint, "timeout": 0.1})
+
+    with pytest.raises(GenerationTimeoutError):
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    cancel.assert_called_once()
+    assert generator.last_request_metadata["cancellation_requested"] is True
+
+
 def test_cancellation_check_attempts_best_effort_cancellation(monkeypatch, tmp_path):
     first, _ = _images(tmp_path)
     endpoint = "bytedance/seedance-2.0/image-to-video"
@@ -440,20 +477,21 @@ def test_strict_output_and_profile_input_validation(monkeypatch, tmp_path):
         "bytedance/seedance-2.0/fast/image-to-video",
     ],
 )
-def test_seedance_profiles_forward_generate_audio(monkeypatch, tmp_path, endpoint):
+def test_seedance_profiles_forward_supported_options(monkeypatch, tmp_path, endpoint):
     first, _ = _images(tmp_path)
     calls = _install_completed_queue(monkeypatch, endpoint)
     generator = FalGenerator(
         {
             "api_key": "test-key",
             "model": endpoint,
-            "default_input": {"generate_audio": False},
+            "default_input": {"generate_audio": False, "seed": 1234},
         }
     )
 
     generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 4)
 
     assert calls[0][2]["json"]["generate_audio"] is False
+    assert calls[0][2]["json"]["seed"] == 1234
 
 
 def test_veo_profile_forwards_generate_audio(monkeypatch, tmp_path):

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -406,6 +406,23 @@ def test_strict_output_and_profile_input_validation(monkeypatch, tmp_path):
         )
 
 
+def test_veo_profile_forwards_generate_audio(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "fal-ai/veo3.1/image-to-video"
+    calls = _install_completed_queue(monkeypatch, endpoint)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": endpoint,
+            "default_input": {"generate_audio": False},
+        }
+    )
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 4)
+
+    assert calls[0][2]["json"]["generate_audio"] is False
+
+
 def test_unprofiled_endpoint_fails_configuration_and_fal_key_is_preferred(monkeypatch):
     with pytest.raises(Exception, match="Unsupported fal.ai model endpoint"):
         FalGenerator({"api_key": "test-key", "model": "fal-ai/unknown"})

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -349,6 +349,40 @@ def test_timeout_attempts_best_effort_cancellation(monkeypatch, tmp_path):
     assert generator.last_request_metadata["cancellation_requested"] is True
 
 
+def test_keyboard_interrupt_attempts_best_effort_cancellation(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    _install_completed_queue(monkeypatch, endpoint)
+    cancel = Mock(return_value=_response(202, {}))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.put", cancel)
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint})
+    monkeypatch.setattr(
+        generator, "_wait_for_completion", Mock(side_effect=KeyboardInterrupt)
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
+
+    cancel.assert_called_once()
+
+
+def test_retry_after_parsing_and_sleep_respect_deadline(monkeypatch):
+    generator = FalGenerator(
+        {"api_key": "test-key", "model": "bytedance/seedance-2.0/image-to-video"}
+    )
+    invalid = _response(429, {}, {"Retry-After": "not-a-date"})
+    delayed = _response(429, {}, {"Retry-After": "3600"})
+    sleep = Mock()
+    monkeypatch.setattr("generators.remote.fal_generator.time.sleep", sleep)
+    monkeypatch.setattr("generators.remote.fal_generator.time.monotonic", lambda: 10)
+    monkeypatch.setattr("generators.remote.fal_generator.random.uniform", lambda *_: 0)
+
+    assert generator._retry_after(invalid) is None
+    with pytest.raises(GenerationTimeoutError):
+        generator._sleep_before_retry(0, delayed, deadline=11)
+    sleep.assert_not_called()
+
+
 def test_strict_output_and_profile_input_validation(monkeypatch, tmp_path):
     first, _ = _images(tmp_path)
     endpoint = "bytedance/seedance-2.0/image-to-video"

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -396,14 +396,37 @@ def test_strict_output_and_profile_input_validation(monkeypatch, tmp_path):
     with pytest.raises(Exception, match="video.url"):
         generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 6)
 
-    with pytest.raises(InvalidInputError, match="generate_audio"):
+    with pytest.raises(InvalidInputError, match="unknown_option"):
         generator.generate_video(
             "move",
             str(first),
             str(tmp_path / "out.mp4"),
             6,
-            fal_input={"generate_audio": False},
+            fal_input={"unknown_option": False},
         )
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "bytedance/seedance-2.0/image-to-video",
+        "bytedance/seedance-2.0/fast/image-to-video",
+    ],
+)
+def test_seedance_profiles_forward_generate_audio(monkeypatch, tmp_path, endpoint):
+    first, _ = _images(tmp_path)
+    calls = _install_completed_queue(monkeypatch, endpoint)
+    generator = FalGenerator(
+        {
+            "api_key": "test-key",
+            "model": endpoint,
+            "default_input": {"generate_audio": False},
+        }
+    )
+
+    generator.generate_video("move", str(first), str(tmp_path / "out.mp4"), 4)
+
+    assert calls[0][2]["json"]["generate_audio"] is False
 
 
 def test_veo_profile_forwards_generate_audio(monkeypatch, tmp_path):

--- a/tests/test_fal_generator.py
+++ b/tests/test_fal_generator.py
@@ -349,6 +349,33 @@ def test_timeout_attempts_best_effort_cancellation(monkeypatch, tmp_path):
     assert generator.last_request_metadata["cancellation_requested"] is True
 
 
+def test_cancellation_check_attempts_best_effort_cancellation(monkeypatch, tmp_path):
+    first, _ = _images(tmp_path)
+    endpoint = "bytedance/seedance-2.0/image-to-video"
+    _install_completed_queue(
+        monkeypatch,
+        endpoint,
+        statuses=[_response(200, {"status": "IN_QUEUE"})],
+    )
+    cancel = Mock(return_value=_response(202, {"status": "CANCELLATION_REQUESTED"}))
+    monkeypatch.setattr("generators.remote.fal_generator.requests.put", cancel)
+    monkeypatch.setattr("generators.remote.fal_generator.time.sleep", lambda *_: None)
+    cancellation_check = Mock(side_effect=[False, True])
+    generator = FalGenerator({"api_key": "test-key", "model": endpoint})
+
+    with pytest.raises(InterruptedError, match="cancelled"):
+        generator.generate_video(
+            "move",
+            str(first),
+            str(tmp_path / "out.mp4"),
+            6,
+            cancellation_check=cancellation_check,
+        )
+
+    cancel.assert_called_once()
+    assert generator.last_request_metadata["cancellation_requested"] is True
+
+
 def test_keyboard_interrupt_attempts_best_effort_cancellation(monkeypatch, tmp_path):
     first, _ = _images(tmp_path)
     endpoint = "bytedance/seedance-2.0/image-to-video"

--- a/tests/test_keyframe_checkpoints.py
+++ b/tests/test_keyframe_checkpoints.py
@@ -130,6 +130,7 @@ def test_keyframes_only_stops_before_video_generation(tmp_path, monkeypatch):
             {
                 "generation_mode": "keyframe",
                 "image_generation_model": "test",
+                "duration_seconds": 8,
             }
         )
     )
@@ -145,8 +146,35 @@ def test_keyframes_only_stops_before_video_generation(tmp_path, monkeypatch):
         )
 
     assert result == str(tmp_path / "output" / "frames")
+    assert "duration_seconds" not in prepare.call_args.args[0]
     prepare.assert_called_once()
     generate_video.assert_not_called()
+
+
+def test_cli_reviewed_plan_restores_trimmed_duration(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_backend": "veo3",
+                "generation_mode": "keyframe",
+                "single_keyframe_mode": True,
+                "image_generation_model": "test",
+            }
+        )
+    )
+    plan = one_shot_plan()
+    plan["segmentation_logic"]["total_duration_seconds"] = 3
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+
+    with patch("pipeline.prepare_keyframes", return_value=["frame.png"]) as prepare:
+        run_pipeline(
+            str(config_path), enhanced_prompt_file=str(plan_path), keyframes_only=True
+        )
+
+    assert prepare.call_args.args[0]["duration_seconds"] == 3
 
 
 def test_plan_only_fails_when_prompt_enhancement_is_skipped(tmp_path, monkeypatch):

--- a/tests/test_keyframe_checkpoints.py
+++ b/tests/test_keyframe_checkpoints.py
@@ -13,6 +13,7 @@ from pipeline import (
     generate_single_video_segment,
     generate_video_segments_sequential,
     run_pipeline,
+    validate_prompt_enhancement,
     validate_existing_keyframes,
 )
 from workers.video_worker import CancellationToken, execute_pipeline_with_config
@@ -49,6 +50,14 @@ def one_shot_plan():
 def test_cut_transition_requires_an_independent_start_prompt():
     with pytest.raises(ValidationError, match="cut keyframes require start_prompt"):
         KeyframePrompt(segment=1, transition="cut", prompt="end")
+
+
+def test_local_plan_validates_cut_frame_reference():
+    plan = one_shot_plan()
+    plan["video_prompts"][0]["first_frame"] = "provided_start_image.png"
+
+    with pytest.raises(ValueError, match="cut transition requires first_frame"):
+        validate_prompt_enhancement(plan, {"default_backend": "wan2.1"})
 
 
 def test_cut_resets_conditioning_and_continue_reuses_previous_end(tmp_path):

--- a/tests/test_keyframe_checkpoints.py
+++ b/tests/test_keyframe_checkpoints.py
@@ -1,0 +1,180 @@
+import json
+import zipfile
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+from PIL import Image
+from pydantic import ValidationError
+
+from api.models import KeyframePrompt
+from keyframe_generator import generate_keyframes_from_json
+from pipeline import run_pipeline, validate_existing_keyframes
+from workers.video_worker import CancellationToken, execute_pipeline_with_config
+from workers.gcs_uploader import create_keyframe_storyboard_archive
+
+
+def one_shot_plan():
+    return {
+        "segmentation_logic": {
+            "total_duration_seconds": 4,
+            "number_of_segments": 1,
+            "reasoning": "test",
+        },
+        "keyframe_prompts": [
+            {
+                "segment": 1,
+                "transition": "cut",
+                "start_prompt": "independent start",
+                "prompt": "same-scene end",
+            }
+        ],
+        "video_prompts": [
+            {
+                "segment": 1,
+                "prompt": "move within the scene",
+                "first_frame": "segment_01_start.png",
+                "last_frame": "segment_01.png",
+                "duration_seconds": 4,
+            }
+        ],
+    }
+
+
+def test_cut_transition_requires_an_independent_start_prompt():
+    with pytest.raises(ValidationError, match="cut keyframes require start_prompt"):
+        KeyframePrompt(segment=1, transition="cut", prompt="end")
+
+
+def test_cut_resets_conditioning_and_continue_reuses_previous_end(tmp_path):
+    plan = {
+        "keyframe_prompts": [
+            {
+                "segment": 1,
+                "transition": "cut",
+                "start_prompt": "ancient scene start",
+                "prompt": "ancient scene end",
+            },
+            {
+                "segment": 2,
+                "transition": "continue",
+                "prompt": "same ancient scene continuation",
+            },
+        ]
+    }
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(plan))
+    frames_dir = tmp_path / "frames"
+
+    def generate(**kwargs):
+        output_path = kwargs["output_path"]
+        with open(output_path, "wb") as file:
+            file.write(b"frame")
+        return output_path
+
+    with patch("keyframe_generator.generate_keyframe", side_effect=generate) as image_call:
+        generated = generate_keyframes_from_json(
+            str(plan_path), str(frames_dir), model_name="test"
+        )
+
+    start_path = str(frames_dir / "segment_01_start.png")
+    first_end_path = str(frames_dir / "segment_01.png")
+    second_end_path = str(frames_dir / "segment_02.png")
+    assert generated == [first_end_path, second_end_path]
+    assert [call.kwargs["input_image_path"] for call in image_call.call_args_list] == [
+        None,
+        start_path,
+        first_end_path,
+    ]
+
+
+def test_keyframes_only_stops_before_video_generation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "generation_mode": "keyframe",
+                "image_generation_model": "test",
+            }
+        )
+    )
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(json.dumps(one_shot_plan()))
+
+    with patch("pipeline.prepare_keyframes", return_value=["frame.png"]) as prepare, \
+         patch("pipeline.generate_video_segments") as generate_video:
+        result = run_pipeline(
+            str(config_path),
+            enhanced_prompt_file=str(plan_path),
+            keyframes_only=True,
+        )
+
+    assert result == str(tmp_path / "output" / "frames")
+    prepare.assert_called_once()
+    generate_video.assert_not_called()
+
+
+def test_storyboard_archive_contains_only_plan_and_frames(tmp_path):
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    (frames_dir / "segment_01_start.png").write_bytes(b"start")
+    (frames_dir / "segment_01.png").write_bytes(b"end")
+    (tmp_path / "unrelated.mp4").write_bytes(b"video")
+
+    archive_path = create_keyframe_storyboard_archive(str(tmp_path), one_shot_plan())
+
+    with zipfile.ZipFile(archive_path) as archive:
+        assert set(archive.namelist()) == {
+            "enhanced_prompt.json",
+            "frames/segment_01.png",
+            "frames/segment_01_start.png",
+        }
+
+
+def test_reviewed_keyframes_require_matching_dimensions(tmp_path):
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    Image.new("RGB", (4, 4)).save(frames_dir / "segment_01_start.png")
+    Image.new("RGB", (8, 4)).save(frames_dir / "segment_01.png")
+
+    with pytest.raises(ValueError, match="keyframe dimensions do not match"):
+        validate_existing_keyframes(one_shot_plan()["video_prompts"], str(tmp_path))
+
+
+def test_api_worker_uploads_storyboard_and_skips_video_generation():
+    plan = one_shot_plan()
+    config = {
+        "keyframes_only": True,
+        "enhanced_prompt": plan,
+        "gcs_bucket": "test-bucket",
+    }
+    token = CancellationToken("storyboard-job")
+    queue = Mock()
+
+    with patch("pipeline.enhance_prompt_data", return_value=plan), \
+         patch(
+             "workers.video_worker.generate_keyframes_with_progress",
+             return_value=["frame.png"],
+         ), \
+         patch("workers.video_worker.generate_video_segments_with_progress") as video, \
+         patch(
+             "workers.gcs_uploader.create_keyframe_storyboard_archive",
+             return_value="/tmp/keyframe_storyboard.zip",
+         ), \
+         patch(
+             "workers.gcs_uploader.upload_named_job_artifact",
+             return_value="gs://test-bucket/job/keyframe_storyboard.zip",
+         ) as upload:
+        result = execute_pipeline_with_config(
+            job_id="storyboard-job",
+            prompt="reviewed plan",
+            config=config,
+            cancellation_token=token,
+            job_queue=queue,
+            processes=[],
+        )
+
+    assert result == "gs://test-bucket/job/keyframe_storyboard.zip"
+    video.assert_not_called()
+    assert upload.call_args.kwargs["artifact_name"] == "keyframe_storyboard.zip"

--- a/tests/test_keyframe_checkpoints.py
+++ b/tests/test_keyframe_checkpoints.py
@@ -93,6 +93,26 @@ def test_cut_resets_conditioning_and_continue_reuses_previous_end(tmp_path):
     ]
 
 
+def test_legacy_first_keyframe_uses_text_to_image_without_initial_frame(tmp_path):
+    plan_path = tmp_path / "plan.json"
+    plan_path.write_text(
+        json.dumps({"keyframe_prompts": [{"segment": 1, "prompt": "opening"}]})
+    )
+    frames_dir = tmp_path / "frames"
+
+    def generate(**kwargs):
+        output_path = kwargs["output_path"]
+        with open(output_path, "wb") as file:
+            file.write(b"frame")
+        return output_path
+
+    with patch("keyframe_generator.generate_keyframe", side_effect=generate) as image_call:
+        generated = generate_keyframes_from_json(str(plan_path), str(frames_dir))
+
+    assert generated == [str(frames_dir / "segment_01.png")]
+    assert image_call.call_args.kwargs["input_image_path"] is None
+
+
 def test_keyframes_only_stops_before_video_generation(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config_path = tmp_path / "config.yaml"
@@ -118,6 +138,18 @@ def test_keyframes_only_stops_before_video_generation(tmp_path, monkeypatch):
     assert result == str(tmp_path / "output" / "frames")
     prepare.assert_called_once()
     generate_video.assert_not_called()
+
+
+def test_plan_only_fails_when_prompt_enhancement_is_skipped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("prompt: test\n")
+    stale_plan = tmp_path / "output" / "enhanced_prompt.json"
+    stale_plan.parent.mkdir()
+    stale_plan.write_text("{}")
+
+    with pytest.raises(ValueError, match="requires an OpenAI API key"):
+        run_pipeline(str(config_path), plan_only=True)
 
 
 def test_storyboard_archive_contains_only_plan_and_frames(tmp_path):

--- a/tests/test_keyframe_checkpoints.py
+++ b/tests/test_keyframe_checkpoints.py
@@ -9,7 +9,12 @@ from pydantic import ValidationError
 
 from api.models import KeyframePrompt
 from keyframe_generator import generate_keyframes_from_json
-from pipeline import run_pipeline, validate_existing_keyframes
+from pipeline import (
+    generate_single_video_segment,
+    generate_video_segments_sequential,
+    run_pipeline,
+    validate_existing_keyframes,
+)
 from workers.video_worker import CancellationToken, execute_pipeline_with_config
 from workers.gcs_uploader import create_keyframe_storyboard_archive
 
@@ -140,6 +145,39 @@ def test_reviewed_keyframes_require_matching_dimensions(tmp_path):
 
     with pytest.raises(ValueError, match="keyframe dimensions do not match"):
         validate_existing_keyframes(one_shot_plan()["video_prompts"], str(tmp_path))
+
+
+def test_local_generators_honor_explicit_cut_start_frame(tmp_path):
+    output_dir = tmp_path / "output"
+    frames_dir = output_dir / "frames"
+    frames_dir.mkdir(parents=True)
+    start = frames_dir / "segment_02_start.png"
+    end = frames_dir / "segment_02.png"
+    start.write_bytes(b"start")
+    end.write_bytes(b"end")
+    prompt = {
+        "segment": 2,
+        "prompt": "new scene",
+        "first_frame": start.name,
+        "last_frame": end.name,
+    }
+
+    with patch("pipeline.run_command") as run_command:
+        generate_single_video_segment(
+            "wan", {"total_gpus": 1}, prompt, str(output_dir), "model"
+        )
+        parallel_command = run_command.call_args.args[0]
+        assert parallel_command[parallel_command.index("--first_frame") + 1] == str(
+            start
+        )
+
+        generate_video_segments_sequential(
+            "wan", {"gpu_count": 1}, [prompt], str(output_dir), "model"
+        )
+        sequential_command = run_command.call_args.args[0]
+        assert sequential_command[sequential_command.index("--first_frame") + 1] == str(
+            start
+        )
 
 
 def test_api_worker_uploads_storyboard_and_skips_video_generation():

--- a/tests/test_keyframe_generator_gemini.py
+++ b/tests/test_keyframe_generator_gemini.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from io import BytesIO
 
 from PIL import Image
 
@@ -9,7 +10,9 @@ def test_gemini_keyframe_generation_uses_google_genai_client(tmp_path, monkeypat
     input_path = tmp_path / "input.png"
     output_path = tmp_path / "output.png"
     Image.new("RGB", (2, 2), color="blue").save(input_path)
-    generated_bytes = input_path.read_bytes()
+    generated_image = BytesIO()
+    Image.new("RGB", (3, 2), color="green").save(generated_image, format="JPEG")
+    generated_bytes = generated_image.getvalue()
 
     generate_content_calls = []
     clients = []
@@ -43,7 +46,9 @@ def test_gemini_keyframe_generation_uses_google_genai_client(tmp_path, monkeypat
     )
 
     assert result == str(output_path.resolve())
-    assert output_path.read_bytes() == generated_bytes
+    with Image.open(output_path) as image:
+        assert image.format == "PNG"
+        assert image.size == (2, 2)
     assert generate_content_calls[0]["model"] == "test-image-model"
     assert generate_content_calls[0]["config"].response_modalities == ["IMAGE"]
     assert generate_content_calls[0]["contents"][-1] == "Turn the square green"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -343,9 +343,11 @@ class TestAuthTokenMiddleware:
 
         client = TestClient(app)
         response = client.get("/v1/jobs/test")
+        plan_response = client.get("/v1/plans/test")
 
         assert response.status_code == 401
         assert response.json()["error"] == "Unauthorized"
+        assert plan_response.status_code == 401
 
     def test_allows_request_with_valid_bearer_token(self):
         app = FastAPI()

--- a/tests/test_trio_video_worker.py
+++ b/tests/test_trio_video_worker.py
@@ -190,6 +190,41 @@ class TestPipelineExecution:
                 mock_stitch.assert_called_once()
                 mock_upload.assert_called_once()
 
+    @pytest.mark.trio
+    async def test_keyframes_only_uploads_storyboard_and_skips_video(self):
+        job_id = "test_storyboard"
+        config = {"keyframes_only": True, "gcs_bucket": "test_bucket"}
+
+        with trio.CancelScope() as cancel_scope:
+            token = TrioCancellationToken(job_id, cancel_scope)
+            mock_queue = Mock()
+
+            with patch(
+                'workers.trio_video_worker.enhance_prompt_trio'
+            ) as mock_enhance, patch(
+                'workers.trio_video_worker.generate_keyframes_trio'
+            ) as mock_keyframes, patch(
+                'workers.trio_video_worker.generate_video_segments_trio'
+            ) as mock_videos, patch(
+                'workers.trio_video_worker.check_cancellation_async',
+                return_value=False,
+            ), patch(
+                'workers.trio_video_worker.trio.to_thread.run_sync',
+                return_value='gs://test_bucket/job/keyframe_storyboard.zip',
+            ):
+                mock_enhance.return_value = {
+                    'keyframe_prompts': [{'segment': 1, 'prompt': 'frame'}],
+                    'video_prompts': [{'segment': 1, 'prompt': 'move'}],
+                }
+                mock_keyframes.return_value = ['frame.png']
+
+                result = await execute_pipeline_with_trio(
+                    job_id, "prompt", config, token, mock_queue, None
+                )
+
+        assert result == 'gs://test_bucket/job/keyframe_storyboard.zip'
+        mock_videos.assert_not_called()
+
 
 class TestPipelineComponents:
     """Test individual pipeline components"""

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -142,8 +142,8 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
     frames_dir = tmp_path / "frames"
     frames_dir.mkdir()
     last_frame = frames_dir / "last.png"
-    first_frame.touch()
-    last_frame.touch()
+    Image.new("RGB", (4, 4)).save(first_frame)
+    Image.new("RGB", (4, 4)).save(last_frame)
     generator = Mock()
 
     with patch("generators.factory.create_video_generator", return_value=generator):
@@ -169,7 +169,7 @@ def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):
 
 def test_inferred_veo_fallback_uses_configured_duration(tmp_path):
     frame = tmp_path / "frame.png"
-    frame.touch()
+    Image.new("RGB", (4, 4)).save(frame)
     generator = Mock()
     generator.generate_video.side_effect = VideoGenerationError("Veo failed")
     fallback = Mock()
@@ -198,7 +198,7 @@ def test_inferred_veo_fallback_uses_configured_duration(tmp_path):
 
 def test_chaining_veo_fallback_uses_configured_duration(tmp_path):
     frame = tmp_path / "frame.png"
-    frame.touch()
+    Image.new("RGB", (4, 4)).save(frame)
     primary = Mock()
     primary.get_backend_name.return_value = "veo3"
     primary.validate_inputs.return_value = []
@@ -236,7 +236,7 @@ def test_chaining_veo_fallback_uses_configured_duration(tmp_path):
 
 def test_requested_duration_disables_incompatible_fallback(tmp_path):
     frame = tmp_path / "frame.png"
-    frame.touch()
+    Image.new("RGB", (4, 4)).save(frame)
     generator = Mock()
     generator.generate_video.side_effect = VideoGenerationError("Veo failed")
 
@@ -276,6 +276,16 @@ def test_veo_factory_forwards_fast_model():
         )
 
     assert generator.model_name == "veo-3.1-fast-generate-001"
+
+
+def test_veo_factory_uses_google_api_key_and_preview_model():
+    with patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}):
+        with patch.object(Veo3Generator, "_init_clients"):
+            generator = create_video_generator("veo3", {"google_veo": {}})
+
+    assert generator.api_key == "test-key"
+    assert generator.model_name == "veo-3.1-generate-preview"
+    assert generator.estimate_cost(8) == 3.2
 
 
 def test_veo_request_contains_model_duration_and_both_frames(tmp_path):
@@ -320,6 +330,66 @@ def test_veo_request_contains_model_duration_and_both_frames(tmp_path):
     assert request["config"].last_frame.gcs_uri == "gs://inputs/last.png"
 
 
+def test_veo_google_api_key_request_uses_local_frames_and_downloads(tmp_path):
+    first_frame = tmp_path / "first.png"
+    last_frame = tmp_path / "last.png"
+    Image.new("RGB", (128, 72)).save(first_frame)
+    Image.new("RGB", (128, 72)).save(last_frame)
+    output_path = tmp_path / "video.mp4"
+    video = Mock()
+    operation = SimpleNamespace(
+        done=True,
+        response=SimpleNamespace(generated_videos=[SimpleNamespace(video=video)]),
+    )
+    generate_videos = Mock(return_value=operation)
+
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = Veo3Generator({"api_key": "test-key", "max_retries": 1})
+    generator.genai_client = SimpleNamespace(
+        models=SimpleNamespace(generate_videos=generate_videos),
+        operations=Mock(),
+        files=SimpleNamespace(download=Mock()),
+    )
+
+    generator.generate_video(
+        prompt="A smooth transition",
+        input_image_path=str(first_frame),
+        last_frame_path=str(last_frame),
+        output_path=str(output_path),
+        duration=8,
+    )
+
+    request = generate_videos.call_args.kwargs
+    assert request["model"] == "veo-3.1-generate-preview"
+    assert request["image"].image_bytes
+    assert request["config"].last_frame.image_bytes
+    assert request["config"].duration_seconds == 8
+    generator.genai_client.files.download.assert_called_once_with(file=video)
+    video.save.assert_called_once_with(str(output_path))
+
+
+def test_veo_google_api_key_does_not_retry_rejected_request(tmp_path):
+    first_frame = tmp_path / "first.png"
+    Image.new("RGB", (128, 72)).save(first_frame)
+    rejected_request = Mock(side_effect=ValueError("invalid request"))
+
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = Veo3Generator({"api_key": "test-key", "max_retries": 3})
+    generator.genai_client = SimpleNamespace(
+        models=SimpleNamespace(generate_videos=rejected_request),
+    )
+
+    with pytest.raises(VideoGenerationError, match="invalid request"):
+        generator.generate_video(
+            prompt="A smooth transition",
+            input_image_path=str(first_frame),
+            output_path=str(tmp_path / "video.mp4"),
+            duration=8,
+        )
+
+    rejected_request.assert_called_once()
+
+
 def test_trim_and_cli_duration_interfaces(tmp_path):
     with patch("pipeline.run_command") as run_command:
         stitch_video_segments(["segment.mp4"], str(tmp_path / "final.mp4"), 9)
@@ -330,7 +400,104 @@ def test_trim_and_cli_duration_interfaces(tmp_path):
     with patch.object(sys, "argv", ["pipeline.py", "--config", "config.yaml", "--duration-seconds", "15"]), \
          patch("pipeline.run_pipeline") as run_pipeline:
         main()
-    run_pipeline.assert_called_once_with("config.yaml", None, 15)
+    run_pipeline.assert_called_once_with(
+        "config.yaml", None, 15, False, None, False, False
+    )
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "pipeline.py",
+            "--config",
+            "config.yaml",
+            "--plan-only",
+            "--enhanced-prompt-file",
+            "reviewed.json",
+        ],
+    ), patch("pipeline.run_pipeline") as run_pipeline:
+        main()
+    run_pipeline.assert_called_once_with(
+        "config.yaml", None, None, True, "reviewed.json", False, False
+    )
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "pipeline.py",
+            "--config",
+            "config.yaml",
+            "--enhanced-prompt-file",
+            "reviewed.json",
+            "--keyframes-only",
+        ],
+    ), patch("pipeline.run_pipeline") as run_pipeline:
+        main()
+    run_pipeline.assert_called_once_with(
+        "config.yaml", None, None, False, "reviewed.json", True, False
+    )
+
+
+def test_reviewed_prompt_plan_skips_llm_and_is_validated():
+    plan = {
+        "segmentation_logic": {
+            "total_duration_seconds": 4,
+            "number_of_segments": 1,
+            "reasoning": "reviewed",
+        },
+        "keyframe_prompts": [{"segment": 1, "prompt": "frame"}],
+        "video_prompts": [{
+            "segment": 1,
+            "prompt": "move",
+            "first_frame": "provided_start_image.png",
+            "last_frame": "segment_01.png",
+            "duration_seconds": 4,
+        }],
+    }
+    config = {
+        "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "duration_seconds": 4,
+        "enhanced_prompt": plan,
+    }
+
+    with patch("pipeline.PromptEnhancer") as prompt_enhancer:
+        assert enhance_prompt_data("unused", config) == plan
+    prompt_enhancer.assert_not_called()
+
+    config["duration_seconds"] = 6
+    with pytest.raises(ValueError, match="requested segment plan"):
+        enhance_prompt_data("unused", config)
+
+
+def test_plan_only_preserves_existing_media(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("prompt: test\n")
+    frame = tmp_path / "output" / "frames" / "existing.png"
+    frame.parent.mkdir(parents=True)
+    frame.write_bytes(b"existing")
+    plan = {
+        "segmentation_logic": {
+            "total_duration_seconds": 5,
+            "number_of_segments": 1,
+            "reasoning": "test",
+        },
+        "keyframe_prompts": [{"segment": 1, "prompt": "frame"}],
+        "video_prompts": [{
+            "segment": 1,
+            "prompt": "move",
+            "duration_seconds": 5,
+        }],
+    }
+
+    with patch("pipeline.enhance_prompt", return_value=plan):
+        result = run_pipeline(str(config_path), plan_only=True)
+
+    assert result == str(tmp_path / "output" / "enhanced_prompt.json")
+    assert frame.read_bytes() == b"existing"
 
 
 def test_duration_limit_and_api_validation():

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -427,7 +427,7 @@ def test_cli_rejects_unsupported_duration_before_generation():
             "single_keyframe_mode": True,
         },
     ), patch("pipeline.enhance_prompt") as enhance_prompt:
-        with pytest.raises(ValueError, match="supported only for the veo3 backend"):
+        with pytest.raises(ValueError, match="supported only for veo3 and fal backends"):
             run_pipeline("config.yaml", duration_seconds=6)
 
     enhance_prompt.assert_not_called()

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -289,6 +289,22 @@ def test_veo_factory_uses_google_api_key_and_preview_model():
     assert generator.estimate_cost(8) == 3.2
 
 
+def test_veo_preview_model_requires_api_key():
+    with patch.dict(
+        "os.environ", {"GOOGLE_API_KEY": "", "GEMINI_API_KEY": ""}
+    ), patch.object(Veo3Generator, "_init_clients"):
+        with pytest.raises(VideoGenerationError, match="Gemini API mode requires"):
+            create_video_generator(
+                "veo3",
+                {
+                    "google_veo": {
+                        "project_id": "test-project",
+                        "veo_model": "veo-3.1-generate-preview",
+                    }
+                },
+            )
+
+
 def test_veo_api_key_normalizes_vertex_model_name():
     with patch.object(Veo3Generator, "_init_clients"):
         generator = Veo3Generator(

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -166,6 +166,8 @@ def test_fallback_to_veo_uses_supported_duration():
 
     assert get_provider_compatible_duration(config, "minimax", "veo3", 5) == 6
     assert get_provider_compatible_duration(config, "fal", "veo3", 9) == 8
+    config["google_veo"] = {"resolution": "1080p"}
+    assert get_provider_compatible_duration(config, "minimax", "veo3", 5) == 8
 
 
 def test_pipeline_forwards_segment_duration_and_both_frames(tmp_path):

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -288,6 +289,23 @@ def test_veo_factory_uses_google_api_key_and_preview_model():
     assert generator.estimate_cost(8) == 3.2
 
 
+def test_veo_factory_does_not_force_developer_api_for_vertex_model():
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = create_video_generator(
+            "veo3",
+            {
+                "google_veo": {
+                    "project_id": "test-project",
+                    "api_key": "developer-key",
+                    "veo_model": "veo-3.1-generate-001",
+                }
+            },
+        )
+
+    assert generator.api_key is None
+    assert generator.model_name == "veo-3.1-generate-001"
+
+
 def test_veo_request_contains_model_duration_and_both_frames(tmp_path):
     first_frame = tmp_path / "first.png"
     last_frame = tmp_path / "last.png"
@@ -493,7 +511,12 @@ def test_plan_only_preserves_existing_media(tmp_path, monkeypatch):
         }],
     }
 
-    with patch("pipeline.enhance_prompt", return_value=plan):
+    def write_plan(*_args):
+        plan_path = tmp_path / "output" / "enhanced_prompt.json"
+        plan_path.write_text(json.dumps(plan))
+        return plan
+
+    with patch("pipeline.enhance_prompt", side_effect=write_plan):
         result = run_pipeline(str(config_path), plan_only=True)
 
     assert result == str(tmp_path / "output" / "enhanced_prompt.json")

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -289,6 +289,15 @@ def test_veo_factory_uses_google_api_key_and_preview_model():
     assert generator.estimate_cost(8) == 3.2
 
 
+def test_veo_api_key_normalizes_vertex_model_name():
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = Veo3Generator(
+            {"api_key": "test-key", "veo_model": "veo-3.1-generate-001"}
+        )
+
+    assert generator.model_name == "veo-3.1-generate-preview"
+
+
 def test_veo_factory_does_not_force_developer_api_for_vertex_model():
     with patch.object(Veo3Generator, "_init_clients"):
         generator = create_video_generator(
@@ -564,10 +573,14 @@ def test_long_requested_duration_batches_prompt_enhancement():
             ],
         }
 
+    final_batch = batch_result([8])
+    final_batch["video_prompts"][0]["first_frame"] = "segment_20.png"
+    final_batch["video_prompts"][0]["last_frame"] = "segment_21.png"
+
     with patch("pipeline.PromptEnhancer") as prompt_enhancer:
         prompt_enhancer.return_value.enhance.side_effect = [
             batch_result([8] * 20),
-            batch_result([8]),
+            final_batch,
         ]
         result = enhance_prompt_data(
             "A long journey",

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -606,6 +606,10 @@ def test_requested_duration_scales_queue_timeout():
     }
     assert get_requested_job_timeout(config) == 3600 + 1805 * 600
 
+    config.pop("duration_seconds")
+    config["enhanced_prompt"] = {"video_prompts": [{}, {}, {}]}
+    assert get_requested_job_timeout(config) == 3600 + 3 * 600
+
 
 def test_cli_rejects_unsupported_duration_before_generation():
     with patch(

--- a/tests/test_veo31_duration.py
+++ b/tests/test_veo31_duration.py
@@ -17,6 +17,7 @@ from pipeline import (
     enhance_prompt_data,
     generate_video_chaining_mode,
     generate_video_segments_single_keyframe,
+    get_backend_clip_durations,
     get_duration_tradeoff,
     get_provider_compatible_duration,
     get_requested_job_timeout,
@@ -129,6 +130,35 @@ def test_omitted_duration_keeps_veo_planning_ai_inferred():
     assert instructions.count('"duration_seconds": 4') >= 2
     assert '"duration_seconds": 5' not in instructions
     assert get_trim_duration_seconds(config) is None
+
+
+@pytest.mark.parametrize("resolution", ["1080p", "4k"])
+def test_high_resolution_veo_plans_and_validates_only_eight_second_clips(
+    tmp_path, resolution
+):
+    config = {
+        "default_backend": "veo3",
+        "generation_mode": "keyframe",
+        "single_keyframe_mode": True,
+        "duration_seconds": 10,
+        "google_veo": {"resolution": resolution},
+    }
+
+    assert get_backend_clip_durations(config) == (8,)
+    assert get_requested_segment_plan(config) == [8, 8]
+
+    frame = tmp_path / "frame.png"
+    Image.new("RGB", (160, 90)).save(frame)
+    with patch.object(Veo3Generator, "_init_clients"):
+        generator = Veo3Generator(
+            {"api_key": "test-key", "resolution": resolution}
+        )
+
+    assert generator.validate_inputs("move", str(frame), 8) == []
+    assert any(
+        "requires an 8-second duration" in error
+        for error in generator.validate_inputs("move", str(frame), 6)
+    )
 
 
 def test_fallback_to_veo_uses_supported_duration():

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -120,7 +120,7 @@ class TestPipelineIntegration:
 
             get_fallback.assert_called_once_with("primary", config)
             fallback.generate_video.assert_called_once()
-            assert result == [os.path.join(output_dir, "segment_001.mp4")]
+            assert result == [os.path.join(output_dir, "videos", "segment_001.mp4")]
 
     def test_single_keyframe_generation_falls_back_when_backend_init_fails(self):
         with tempfile.TemporaryDirectory() as output_dir:
@@ -136,7 +136,7 @@ class TestPipelineIntegration:
                  patch("generators.factory.get_fallback_generator", return_value=fallback):
                 result = generate_video_segments_single_keyframe(config, prompts, output_dir)
 
-            expected_path = os.path.join(output_dir, "segment_001.mp4")
+            expected_path = os.path.join(output_dir, "videos", "segment_001.mp4")
             assert fallback.generate_video.call_args.kwargs["output_path"] == expected_path
             assert result == [expected_path]
 

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -256,7 +256,8 @@ class TestPipelineIntegration:
         mock_generate_segments.assert_called_once_with(
             config=config,
             video_prompts=video_prompts,
-            output_dir='/tmp/test'
+            output_dir='/tmp/test',
+            cancellation_check=cancellation_token.is_cancelled,
         )
     
     @patch('workers.gcs_uploader.upload_job_artifact')

--- a/tests/test_worker_integration.py
+++ b/tests/test_worker_integration.py
@@ -74,8 +74,8 @@ class TestPipelineIntegration:
 
             with open(os.path.join(frames_dir, "segment_00.png"), "rb") as file:
                 assert file.read() == b"start"
-            assert video_prompts[0]["first_frame"] == os.path.join(frames_dir, "segment_00.png")
-            assert video_prompts[1]["last_frame"] == os.path.join(frames_dir, "segment_02.png")
+            assert video_prompts[0]["first_frame"] == "provided_start_image.png"
+            assert video_prompts[1]["last_frame"] == "segment_02.png"
 
     def test_prepare_keyframes_keeps_start_already_named_segment_zero(self):
         with tempfile.TemporaryDirectory() as output_dir:
@@ -100,7 +100,7 @@ class TestPipelineIntegration:
 
             with open(initial_image, "rb") as file:
                 assert file.read() == b"start"
-            assert video_prompts[0]["first_frame"] == initial_image
+            assert video_prompts[0]["first_frame"] == "provided_start_image.png"
 
     def test_single_keyframe_generation_uses_typed_error_fallback(self):
         with tempfile.TemporaryDirectory() as output_dir:

--- a/video_generator_interface.py
+++ b/video_generator_interface.py
@@ -128,10 +128,12 @@ class VideoGenerationError(Exception):
 
 class APIError(VideoGenerationError):
     """Exception for API-related errors"""
-    def __init__(self, message: str, status_code: Optional[int] = None, response_body: Optional[str] = None):
+    def __init__(self, message: str, status_code: Optional[int] = None,
+                 response_body: Optional[str] = None, error_type: Optional[str] = None):
         super().__init__(message)
         self.status_code = status_code
         self.response_body = response_body
+        self.error_type = error_type
 
 
 class GenerationTimeoutError(VideoGenerationError):

--- a/workers/gcs_uploader.py
+++ b/workers/gcs_uploader.py
@@ -5,7 +5,9 @@ This module provides a simple interface for workers to upload video artifacts
 to Google Cloud Storage and update job status with GCS URIs.
 """
 
+import json
 import logging
+import zipfile
 from pathlib import Path
 from typing import Optional
 
@@ -245,4 +247,44 @@ def upload_job_artifact(
         local_video_path=local_video_path,
         job_id=job_id,
         cleanup_local=cleanup_local
+    )
+
+
+def create_keyframe_storyboard_archive(output_dir: str, plan: dict) -> str:
+    """Package a plan and its generated frames into a durable ZIP artifact."""
+    output_path = Path(output_dir)
+    frames_path = output_path / "frames"
+    if not frames_path.is_dir():
+        raise FileNotFoundError(f"Keyframe directory not found: {frames_path}")
+
+    plan_path = output_path / "enhanced_prompt.json"
+    with plan_path.open("w", encoding="utf-8") as file:
+        json.dump(plan, file, indent=2)
+        file.write("\n")
+
+    archive_path = output_path / "keyframe_storyboard.zip"
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(plan_path, plan_path.name)
+        for frame_path in sorted(frames_path.rglob("*")):
+            if frame_path.is_file():
+                archive.write(frame_path, frame_path.relative_to(output_path))
+    return str(archive_path)
+
+
+def upload_named_job_artifact(
+    local_file_path: str,
+    job_id: str,
+    gcs_config: GCSConfig,
+    artifact_name: str,
+    cleanup_local: bool = False,
+) -> Optional[str]:
+    """Upload a non-video job artifact under an explicit filename."""
+    uploader = create_worker_uploader(gcs_config)
+    if not uploader:
+        return None
+    return uploader.upload_additional_artifact(
+        local_file_path=local_file_path,
+        job_id=job_id,
+        artifact_name=artifact_name,
+        cleanup_local=cleanup_local,
     )

--- a/workers/trio_video_worker.py
+++ b/workers/trio_video_worker.py
@@ -491,7 +491,8 @@ async def generate_video_segments_trio(
             return generate_video_segments_single_keyframe(
                 config=config,
                 video_prompts=video_prompts,
-                output_dir=output_dir
+                output_dir=output_dir,
+                cancellation_check=cancellation_token.is_cancelled,
             )
         else:
             # Use local Wan2.1 generation

--- a/workers/trio_video_worker.py
+++ b/workers/trio_video_worker.py
@@ -240,6 +240,46 @@ async def execute_pipeline_with_trio(
         )
         
         logger.info(f"Generated {len(keyframe_paths)} keyframes")
+
+        if final_config.get("keyframes_only"):
+            if await check_cancellation_async(cancellation_token, job_id):
+                raise InterruptedError(f"Job {job_id} cancelled before storyboard upload")
+
+            job_queue.update_job_status(job_id, JobStatus.PROGRESS, progress=90)
+            job_queue.add_job_log(job_id, "Uploading keyframe storyboard artifact")
+
+            def package_and_upload_storyboard():
+                from api.config import GCSConfig
+                from workers.gcs_uploader import (
+                    create_keyframe_storyboard_archive,
+                    upload_named_job_artifact,
+                )
+
+                archive_path = create_keyframe_storyboard_archive(
+                    job_output_dir, enhancement_result
+                )
+                return upload_named_job_artifact(
+                    local_file_path=archive_path,
+                    job_id=job_id,
+                    gcs_config=GCSConfig(
+                        bucket=final_config.get('gcs_bucket', 'ttv-api-artifacts'),
+                        prefix=final_config.get('gcs_prefix', 'ttv-api'),
+                        credentials_path=final_config.get(
+                            'credentials_path', 'credentials.json'
+                        ),
+                        signed_url_expiration=final_config.get(
+                            'signed_url_expiration', 3600
+                        ),
+                    ),
+                    artifact_name="keyframe_storyboard.zip",
+                )
+
+            gcs_uri = await trio.to_thread.run_sync(package_and_upload_storyboard)
+            if not gcs_uri:
+                raise Exception("Storyboard upload returned None - upload failed")
+            job_queue.update_job_status(job_id, JobStatus.PROGRESS, progress=95)
+            job_queue.add_job_log(job_id, f"Storyboard upload completed: {gcs_uri}")
+            return gcs_uri
         
         # Phase 5: Video segment generation (80%)
         if await check_cancellation_async(cancellation_token, job_id):

--- a/workers/video_worker.py
+++ b/workers/video_worker.py
@@ -452,6 +452,42 @@ def execute_pipeline_with_config(
             )
             
             logger.info(f"Generated {len(keyframe_paths)} keyframes")
+
+            if final_config.get("keyframes_only"):
+                if check_cancellation(cancellation_token, job_id):
+                    raise InterruptedError("Job cancelled before storyboard upload")
+
+                job_queue.update_job_status(job_id, JobStatus.PROGRESS, progress=90)
+                job_queue.add_job_log(job_id, "Uploading keyframe storyboard artifact")
+                from api.config import GCSConfig
+                from workers.gcs_uploader import (
+                    create_keyframe_storyboard_archive,
+                    upload_named_job_artifact,
+                )
+
+                archive_path = create_keyframe_storyboard_archive(
+                    job_output_dir, enhancement_result
+                )
+                gcs_uri = upload_named_job_artifact(
+                    local_file_path=archive_path,
+                    job_id=job_id,
+                    gcs_config=GCSConfig(
+                        bucket=final_config.get('gcs_bucket', 'ttv-api-artifacts'),
+                        prefix=final_config.get('gcs_prefix', 'ttv-api'),
+                        credentials_path=final_config.get(
+                            'credentials_path', 'credentials.json'
+                        ),
+                        signed_url_expiration=final_config.get(
+                            'signed_url_expiration', 3600
+                        ),
+                    ),
+                    artifact_name="keyframe_storyboard.zip",
+                )
+                if not gcs_uri:
+                    raise Exception("Storyboard upload returned None - upload failed")
+                job_queue.update_job_status(job_id, JobStatus.PROGRESS, progress=95)
+                job_queue.add_job_log(job_id, f"Storyboard upload completed: {gcs_uri}")
+                return gcs_uri
             
             # Phase 5: Video segment generation (80%)
             if check_cancellation(cancellation_token, job_id):

--- a/workers/video_worker.py
+++ b/workers/video_worker.py
@@ -661,7 +661,8 @@ def generate_video_segments_with_progress(
             video_paths = generate_video_segments_single_keyframe(
                 config=config,
                 video_prompts=video_prompts,
-                output_dir=output_dir
+                output_dir=output_dir,
+                cancellation_check=cancellation_token.is_cancelled,
             )
         else:
             # Use local Wan2.1 generation


### PR DESCRIPTION
## Summary

- make fal.ai a first-class profiled provider for Seedance, MiniMax/Hailuo, and Veo endpoints, with validated model-specific inputs and durations
- use the durable fal queue lifecycle with bounded rate-limit/transient retries, cancellation, and ephemeral request, timing, billing, and output metadata for future persistence
- add reviewable prompt and storyboard checkpoints through `--plan-only`, `--enhanced-prompt-file`, `--keyframes-only`, `--reuse-keyframes`, `POST /v1/plans`, and API keyframe-only jobs
- distinguish explicit scene `cut` transitions from same-scene `continue` shots so new eras, locations, and subjects reset image conditioning instead of leaking prior characters
- package API storyboard jobs as a plan-plus-frames ZIP and validate reviewed frame presence and dimensions before paid video submission
- normalize Gemini image output to real PNG data and preserve edit dimensions
- support Veo 3.1 through `GOOGLE_API_KEY` as well as Vertex configuration while forwarding first frame, last frame, model, and requested duration
- update the roadmap and provider documentation for the longer-form, scene-oriented direction

## Why

The previous pipeline could decompose and immediately generate media, but it did not provide a reliable human review boundary. It also reused each prior keyframe across every segment, which could carry ancient subjects into unrelated modern scenes. These changes make plans and keyframes inspectable and resumable, and give the planner explicit scene-boundary semantics.

fal.ai also previously behaved like a generic endpoint wrapper. The profiled implementation now treats endpoint schemas and capabilities as explicit contracts and lays the non-persistent metadata foundation needed for later timing, usage, and cost analysis.

## Validation

- `57 passed` in the focused plan, keyframe, Veo, API worker, Trio worker, and integration suite
- `ruff check --select E9` passed for all changed Python files
- `git diff --check` passed
- storyboard preflight passed for the reviewed 31-frame Mobile Assassin plan
- full branch suite: `386 passed, 103 failed, 4 skipped`
- detached `origin/main` baseline: `349 passed, 111 failed, 4 skipped`

The remaining full-suite failures are baseline repository issues, primarily missing Angie files, stale or uninitialized API fixtures, and Trio compatibility cases; this branch reduces the failing count relative to `origin/main`.

## Follow-up boundary

CLI resume can use locally edited keyframes today. API keyframe-only jobs currently export the reviewed plan and frames as a ZIP; accepting edited frames back through a persistent storyboard resource/upload API is intentionally left for the frontend/HITL phase.